### PR TITLE
fix file names generation for nested subprojects

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -28,10 +28,10 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import org.jenkinsci.plugins.sonargerrit.data.ComponentPathBuilder;
 import org.jenkinsci.plugins.sonargerrit.data.SonarReportBuilder;
 import org.jenkinsci.plugins.sonargerrit.data.converter.CustomIssueFormatter;
 import org.jenkinsci.plugins.sonargerrit.data.converter.CustomReportFormatter;
-import org.jenkinsci.plugins.sonargerrit.data.entity.Component;
 import org.jenkinsci.plugins.sonargerrit.data.entity.Issue;
 import org.jenkinsci.plugins.sonargerrit.data.entity.Report;
 import org.jenkinsci.plugins.sonargerrit.data.entity.Severity;
@@ -66,7 +66,6 @@ public class SonarToGerritPublisher extends Publisher {
     private static final ReviewInput.NotifyHandling DEFAULT_NOTIFICATION_NO_ISSUES = ReviewInput.NotifyHandling.NONE;
     private static final ReviewInput.NotifyHandling DEFAULT_NOTIFICATION_ISSUES = ReviewInput.NotifyHandling.OWNER;
 
-    public static final String GERRIT_FILE_DELIMITER = "/";
     public static final String EMPTY_STR = "";
 
     private static final Logger LOGGER = Logger.getLogger(SonarToGerritPublisher.class.getName());
@@ -119,6 +118,22 @@ public class SonarToGerritPublisher extends Publisher {
         // old values - not used anymore. will be deleted in further releases
         this.path = null;
         this.projectPath = null;
+    }
+
+
+    @VisibleForTesting
+    static Multimap<String, Issue> generateFilenameToIssuesMapFilteredByPredicates(String projectPath, Report report, Iterable<Issue> filtered) {
+	final Multimap<String, Issue> file2issues = LinkedListMultimap.create();
+	// generating map consisting of real file names to corresponding issues
+	// collections.
+	final ComponentPathBuilder pathBuilder = new ComponentPathBuilder(report.getComponents());
+	for (Issue issue : filtered) {
+	    String issueComponent = issue.getComponent();
+	    String realFileName = pathBuilder.buildPrefixedPathForComponentWithKey(issueComponent, projectPath)
+		    .or(issueComponent);
+	    file2issues.put(realFileName, issue);
+	}
+	return file2issues;
     }
 
 
@@ -427,52 +442,6 @@ public class SonarToGerritPublisher extends Publisher {
                 }
             }
         }
-    }
-
-    @VisibleForTesting
-    Multimap<String, Issue> generateFilenameToIssuesMapFilteredByPredicates(String projectPath, Report report, Iterable<Issue> filtered) {
-        Multimap<String, Issue> file2issues = LinkedListMultimap.create();
-
-/*       The next code prepares data to process situations like this one:
-        {
-            "key": "com.maxifier.guice:guice-bootstrap",
-            "path": "guice-bootstrap"
-        },
-        {
-            "key": "com.maxifier.guice:guice-bootstrap:src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java",
-            "path": "src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java",
-            "moduleKey": "com.maxifier.guice:guice-bootstrap",
-            "status": "SAME"
-        }
-        */
-        Map<String, String> component2module = Maps.newHashMap();
-        Map<String, String> component2path = Maps.newHashMap();
-
-        for (Component component : report.getComponents()) {
-            component2path.put(component.getKey(), component.getPath());
-        }
-        for (Component component : report.getComponents()) {
-            if (component.getModuleKey() != null) {
-                component2module.put(component.getKey(), component2path.get(component.getModuleKey()));
-            }
-        }
-
-
-        // generating map consisting of real file names to corresponding issues collections.
-        for (Issue issue : filtered) {
-            String issueComponent = issue.getComponent();
-            String moduleName = component2module.get(issueComponent);
-            String componentPath = component2path.get(issueComponent);
-
-            String realFileName = appendDelimiter(projectPath) + appendDelimiter(moduleName) + componentPath;
-            file2issues.put(realFileName, issue);
-
-        }
-        return file2issues;
-    }
-
-    private String appendDelimiter(String subPath) {
-        return subPath == null || subPath.trim().isEmpty() ? EMPTY_STR : subPath.endsWith(GERRIT_FILE_DELIMITER) ? subPath : subPath + GERRIT_FILE_DELIMITER;
     }
 
     @VisibleForTesting

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/data/ComponentPathBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/data/ComponentPathBuilder.java
@@ -1,0 +1,188 @@
+package org.jenkinsci.plugins.sonargerrit.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jenkinsci.plugins.sonargerrit.data.entity.Component;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+/**
+ * Processes data like below to build file path of a Sonar component.
+ *
+ * <pre>
+ *
+    {
+        "key": "com.maxifier.guice:guice-bootstrap",
+        "path": "guice-bootstrap"
+    },
+    {
+        "key": "com.maxifier.guice:guice-bootstrap:src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java",
+        "path": "src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java",
+        "moduleKey": "com.maxifier.guice:guice-bootstrap",
+        "status": "SAME"
+    }
+ * </pre>
+ */
+public class ComponentPathBuilder {
+
+    private final Map<String, Node> nodes = Maps.newHashMap();
+
+    public ComponentPathBuilder(final List<Component> components) {
+	checkNotNull(components);
+	for (final Component c : components) {
+	    nodes.put(c.getKey(), new Node(c));
+	}
+    }
+
+    public Optional<String> buildPrefixedPathForComponentWithKey(final String componentKey, final String prefix) {
+	Node n = getNodeByComponentKey(componentKey);
+	if (n != null) {
+	    connectAncestors(n);
+	    return Optional.of(n.buildPrefixedPath(Strings.nullToEmpty(prefix)));
+	}
+	return Optional.absent();
+    }
+
+    private void connectAncestors(final Node n) {
+	// already connected
+	if (n.isParentConnected()) {
+	    return;
+	}
+	final Optional<Node> parent = findParent(n);
+	n.setParent(parent);
+	if (parent.isPresent()) {
+	    connectAncestors(parent.get());
+	}
+    }
+
+    private Optional<Node> findParent(final Node n) {
+	if (n.getComponent().getModuleKey() != null) {
+	    return findParentOfSourceFile(n);
+	} else {
+	    return findParentOfModule(n);
+	}
+    }
+
+    private Optional<Node> findParentOfSourceFile(final Node n) {
+	return Optional.fromNullable(getNodeByComponentKey(n.getComponent().getModuleKey()));
+    }
+
+    private Optional<Node> findParentOfModule(final Node n) {
+	final String componentKey = n.getComponent().getKey();
+	final int moduleSeparatorPos = componentKey.lastIndexOf(':');
+	if (moduleSeparatorPos < 0) {
+	    return Optional.absent();
+	}
+	final String parentKeyTemplate = componentKey.substring(0, moduleSeparatorPos);
+
+	Node parent = getNodeByComponentKey(parentKeyTemplate);
+	if (parent != null) {
+	    return Optional.of(parent);
+	}
+	// find parent by replacing *one* '.' with ':' in back-to-front order
+	// e.g. "base.guice:events", "base:guice.events"
+	int dotPosition = parentKeyTemplate.length();
+	while (parent == null) {
+	    dotPosition = parentKeyTemplate.lastIndexOf('.', dotPosition - 1);
+	    if (dotPosition < 0) {
+		return Optional.absent();
+	    }
+	    final String parentKey = parentKeyTemplate.substring(0, dotPosition) + ":"
+		    + parentKeyTemplate.substring(dotPosition + 1);
+	    parent = getNodeByComponentKey(parentKey);
+	}
+	return Optional.of(parent);
+    }
+
+    private Node getNodeByComponentKey(final String componentKey) {
+	return nodes.get(componentKey);
+    }
+
+    private static class Node {
+	private static final String GERRIT_FILE_DELIMITER = "/";
+
+	private final Component component;
+
+	private Node parent;
+
+	public Node(final Component c) {
+	    checkNotNull(c);
+	    this.component = c;
+	}
+
+	private static void appendFileDelimiterIfNecessary(final StringBuilder path) {
+	    if (path.length() > 0 && !pathEndsWith(path, GERRIT_FILE_DELIMITER)) {
+		path.append(GERRIT_FILE_DELIMITER);
+	    }
+	}
+
+	private static boolean pathEndsWith(final StringBuilder path, final String suffix) {
+	    final int excess = path.length() - suffix.length();
+	    if (excess < 0) {
+		return false;
+	    }
+	    for (int i = 0; i < suffix.length(); i++) {
+		if (path.charAt(excess + i) != suffix.charAt(i)) {
+		    return false;
+		}
+	    }
+	    return true;
+	}
+
+	public String buildPrefixedPath(final String prefix) {
+	    final StringBuilder path = new StringBuilder(prefix);
+	    buildPath(path);
+	    return path.toString();
+	}
+
+	protected void buildPath(final StringBuilder path) {
+	    if (isParentFound()) {
+		getParent().buildPath(path);
+	    }
+	    final String thisPath = component.getPath();
+	    if (!Strings.isNullOrEmpty(thisPath)) {
+		appendFileDelimiterIfNecessary(path);
+		path.append(thisPath);
+	    }
+	}
+
+	public Component getComponent() {
+	    return component;
+	}
+
+	public Node getParent() {
+	    return parent;
+	}
+
+	public void setParent(final Optional<Node> parent) {
+	    checkNotNull(parent);
+	    this.parent = parent.or(this);
+	}
+
+	/**
+	 * Answers whether attempt to connect this node to parent has been
+	 * attempted/completed.
+	 */
+	public boolean isParentConnected() {
+	    return parent != null;
+	}
+
+	/**
+	 * Answers whether a parent of this node has been found.
+	 * 
+	 * @return {@code true} if parent has been found; {@code false} if
+	 *         parent has not been found or attempt has not been performed
+	 *         to find parent of this node
+	 */
+	public boolean isParentFound() {
+	    return parent != null && parent != this;
+	}
+
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
@@ -75,10 +75,11 @@ public class SonarToGerritPublisherTest {
     public void testGenerateRealNameMap() throws InterruptedException, IOException, URISyntaxException {
         Report report = readreport();
         Assert.assertEquals(19, report.getIssues().size());
-        Multimap<String, Issue> multimap = new SonarToGerritPublisher("", null, Severity.CRITICAL.name(), true, false, "", "", "", true, "", "0", "0", "", "").generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
+        Multimap<String, Issue> multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
 
         Assert.assertEquals(19, multimap.size());
         Assert.assertEquals(8, multimap.keySet().size());
+        System.out.println(multimap.keySet());
         Assert.assertEquals(1, multimap.get("guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java").size());
         Assert.assertEquals(2, multimap.get("guice-jpa/src/main/java/com/magenta/guice/jpa/DBInterceptor.java").size());
         Assert.assertEquals(8, multimap.get("guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/PluginsManager.java").size());
@@ -88,7 +89,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, multimap.get("guice-events/src/main/java/com/magenta/guice/events/EventDispatcher.java").size());
         Assert.assertEquals(1, multimap.get("src/main/java/com/aquarellian/sonar-gerrit/ObjectHelper.java").size());
 
-        multimap = new SonarToGerritPublisher(null, null, Severity.CRITICAL.name(), true, false, "", "", "", true, "", "0", "0", "", "").generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
+        multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
 
         Assert.assertEquals(19, multimap.size());
         Assert.assertEquals(8, multimap.keySet().size());
@@ -102,7 +103,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, multimap.get("src/main/java/com/aquarellian/sonar-gerrit/ObjectHelper.java").size());
 
         SubJobConfig config = new SubJobConfig("testfolder", "");
-        multimap = new SonarToGerritPublisher("", Arrays.asList(config), Severity.CRITICAL.name(), true, false, "", "", "", true, "", "0", "0", "", "").generateFilenameToIssuesMapFilteredByPredicates(config.getProjectPath(), report, report.getIssues());
+        multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates(config.getProjectPath(), report, report.getIssues());
         Assert.assertEquals(19, multimap.size());
         Assert.assertEquals(8, multimap.keySet().size());
         Assert.assertEquals(1, multimap.get("testfolder/guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java").size());
@@ -115,7 +116,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, multimap.get("testfolder/src/main/java/com/aquarellian/sonar-gerrit/ObjectHelper.java").size());
 
         config = new SubJobConfig("testfolder/", "");
-        multimap = new SonarToGerritPublisher("", Arrays.asList(config), Severity.CRITICAL.name(), true, false, "", "", "", true, "", "0", "0", "", "").generateFilenameToIssuesMapFilteredByPredicates(config.getProjectPath(), report, report.getIssues());
+        multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates(config.getProjectPath(), report, report.getIssues());
         Assert.assertEquals(19, multimap.size());
         Assert.assertEquals(8, multimap.keySet().size());
         Assert.assertEquals(1, multimap.get("testfolder/guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/ChildModule.java").size());
@@ -145,6 +146,15 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, multimap.get("testfolder2/guice-events/src/main/java/com/magenta/guice/events/EnumMatcher.java").size());
         Assert.assertEquals(1, multimap.get("testfolder2/guice-events/src/main/java/com/magenta/guice/events/EventDispatcher.java").size());
         Assert.assertEquals(1, multimap.get("testfolder2/src/main/java/com/aquarellian/sonar-gerrit/ObjectHelper.java").size());
+
+        report = readreport("report3_with-nested-subprojects.json");
+        config = new SubJobConfig("testfolder/", "");
+        multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates(config.getProjectPath(), report, report.getIssues());
+        Assert.assertEquals(6, multimap.size());
+        Assert.assertEquals(3, multimap.get("testfolder/base/core/proj1/src/main/java/proj1/Proj1.java").size());
+        Assert.assertEquals(1, multimap.get("testfolder/base/core/proj2/src/main/java/com/proj2/Proj2.java").size());
+        Assert.assertEquals(1, multimap.get("testfolder/base/com.acme.util/src/main/java/com/acme/util/Util.java").size());
+        Assert.assertEquals(1, multimap.get("testfolder/com.acme.app/src/main/java/com/acme/app/App.java").size());
     }
 
     @Test
@@ -152,8 +162,7 @@ public class SonarToGerritPublisherTest {
         Report report = readreport();
         Assert.assertEquals(19, report.getIssues().size());
 
-        SonarToGerritPublisher builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", true, "", "0", "0", "", "");
-        Multimap<String, Issue> multimap = builder.generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
+        Multimap<String, Issue> multimap = SonarToGerritPublisher.generateFilenameToIssuesMapFilteredByPredicates("", report, report.getIssues());
 
         // Map will describe which strings in each file should be marked as modified.
         // integer values are count of strings that affected by ContentEntry.
@@ -168,6 +177,7 @@ public class SonarToGerritPublisherTest {
         RevisionApi revApi = new DummyRevisionApi(path2changedValues);
 
 
+        SonarToGerritPublisher builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", true, "", "0", "0", "", "");
         builder.filterIssuesByChangedLines(multimap, revApi);
 
         // list of lines commented by sonar : 37, 54,81, 99, 106, 108, 122, 162

--- a/src/test/resources/report3_with-nested-subprojects.json
+++ b/src/test/resources/report3_with-nested-subprojects.json
@@ -1,0 +1,33 @@
+{"version":"5.3",
+	"issues":[
+		{"key":"0154288612E6D93A65","component":"sonar.gerrit.report.base.core:proj1:src/main/java/proj1/Proj1.java","line":5,"startLine":5,"startOffset":16,"endLine":5,"endOffset":24,"message":"Make BadProj1 a static final constant or non-public and provide accessors if needed.","severity":"MAJOR","rule":"squid:ClassVariableVisibilityCheck","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"},
+		{"key":"0154288612E6D93A66","component":"sonar.gerrit.report.base.core:proj1:src/main/java/proj1/Proj1.java","line":5,"startLine":5,"startOffset":16,"endLine":5,"endOffset":24,"message":"Rename this field \"BadProj1\" to match the regular expression '^[a-z][a-zA-Z0-9]*$'.","severity":"MINOR","rule":"squid:S00116","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"},
+		{"key":"0154288612E6D93A67","component":"sonar.gerrit.report.base.core:proj1:src/main/java/proj1/Proj1.java","line":1,"startLine":1,"startOffset":8,"endLine":1,"endOffset":13,"message":"Rename this package name to match the regular expression '^[a-z]+(\\.[a-z][a-z0-9]*)*$'.","severity":"MINOR","rule":"squid:S00120","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"},
+		{"key":"0154288612E7D93A68","component":"sonar.gerrit.report.base.core:proj2:src/main/java/com/proj2/Proj2.java","line":5,"startLine":5,"startOffset":16,"endLine":5,"endOffset":24,"message":"Make badProj2 a static final constant or non-public and provide accessors if needed.","severity":"MAJOR","rule":"squid:ClassVariableVisibilityCheck","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"},
+		{"key":"0154288612E3D93A64","component":"sonar.gerrit.report.base:com.acme.util:src/main/java/com/acme/util/Util.java","line":4,"startLine":4,"startOffset":16,"endLine":4,"endOffset":23,"message":"Make badUtil a static final constant or non-public and provide accessors if needed.","severity":"MAJOR","rule":"squid:ClassVariableVisibilityCheck","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"},
+		{"key":"0154288612E7D93A69","component":"sonar.gerrit.report:com.acme.app:src/main/java/com/acme/app/App.java","line":5,"startLine":5,"startOffset":16,"endLine":5,"endOffset":22,"message":"Make badApp a static final constant or non-public and provide accessors if needed.","severity":"MAJOR","rule":"squid:ClassVariableVisibilityCheck","status":"OPEN","isNew":true,"creationDate":"2016-04-18T16:39:05+0800"}
+	],
+	"components":[
+		{"key":"project.key"},
+		{"key":"sonar.gerrit.report:base","path":"base"},
+		{"key":"sonar.gerrit.report.base:com.acme.util","path":"com.acme.util"},
+		{"key":"sonar.gerrit.report.base:core","path":"core"},
+		{"key":"sonar.gerrit.report.base.core:proj1","path":"proj1"},
+		{"key":"sonar.gerrit.report.base.core:proj2","path":"proj2"},
+		{"key":"sonar.gerrit.report:com.acme.app","path":"com.acme.app"},
+		{"key":"sonar.gerrit.report.base.core:proj1:src/main/java/proj1/Proj1.java","path":"src/main/java/proj1/Proj1.java","moduleKey":"sonar.gerrit.report.base.core:proj1","status":"ADDED"},
+		{"key":"sonar.gerrit.report.base.core:proj2:src/main/java/com/proj2/Proj2.java","path":"src/main/java/com/proj2/Proj2.java","moduleKey":"sonar.gerrit.report.base.core:proj2","status":"ADDED"},
+		{"key":"sonar.gerrit.report.base:com.acme.util:src/main/java/com/acme/util/Util.java","path":"src/main/java/com/acme/util/Util.java","moduleKey":"sonar.gerrit.report.base:com.acme.util","status":"ADDED"},
+		{"key":"sonar.gerrit.report:com.acme.app:src/main/java/com/acme/app/App.java","path":"src/main/java/com/acme/app/App.java","moduleKey":"sonar.gerrit.report:com.acme.app","status":"ADDED"},
+		{"key":"sonar.gerrit.report.base.core:proj1:src/main/java/proj1","path":"src/main/java/proj1","moduleKey":"sonar.gerrit.report.base.core:proj1"},
+		{"key":"sonar.gerrit.report.base.core:proj2:src/main/java/com/proj2","path":"src/main/java/com/proj2","moduleKey":"sonar.gerrit.report.base.core:proj2"},
+		{"key":"sonar.gerrit.report.base:com.acme.util:src/main/java/com/acme/util","path":"src/main/java/com/acme/util","moduleKey":"sonar.gerrit.report.base:com.acme.util"},
+		{"key":"sonar.gerrit.report:com.acme.app:src/main/java/com/acme/app","path":"src/main/java/com/acme/app","moduleKey":"sonar.gerrit.report:com.acme.app"}
+	],
+	"rules":[
+		{"key":"squid:S00120","rule":"S00120","repository":"squid","name":"Package names should comply with a naming convention"},
+		{"key":"squid:S00116","rule":"S00116","repository":"squid","name":"Field names should comply with a naming convention"},
+		{"key":"squid:ClassVariableVisibilityCheck","rule":"ClassVariableVisibilityCheck","repository":"squid","name":"Class variable fields should not have public accessibility"}
+	],
+	"users":[]
+}


### PR DESCRIPTION
When using SonarQube gradle plugin to perform analysis on gradle multi-projects with multiple nested
levels, the path of module component in the exported `sonar-report.json` is not the full path but the path
component of the module.

This commit fixes that by by walking up the parent of the module and collecting the path components
to build the full path.
