### PR TITLE
Upgrading the gerrit-rest-java-client dependency to 0.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.urswolfer.gerrit.client.rest</groupId>
             <artifactId>gerrit-rest-java-client</artifactId>
-            <version>0.8.5</version>
+            <version>0.8.11</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
@@ -4,10 +4,14 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gerrit.extensions.api.changes.*;
+import com.google.gerrit.extensions.client.SubmitType;
+import com.google.gerrit.extensions.common.ActionInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.common.DiffInfo;
 import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.common.MergeableInfo;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gerrit.extensions.common.TestSubmitRuleInput;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import hudson.FilePath;
@@ -194,7 +198,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, reviewResult.comments.size());
         Assert.assertEquals(1, reviewResult.labels.size());
         Assert.assertEquals(-1, reviewResult.labels.get("Test").intValue());
-        Assert.assertEquals(ReviewInput.NotifyHandling.OWNER, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
                 "No Issues Header", "Some Issues Header", "Issue Comment", false, "Test", "1", "-1", null, null);
@@ -202,7 +206,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals("Some Issues Header", reviewResult.message);
         Assert.assertEquals(1, reviewResult.comments.size());
         Assert.assertEquals(null, reviewResult.labels);
-        Assert.assertEquals(ReviewInput.NotifyHandling.OWNER, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
                 "No Issues Header", "Some Issues Header", "Issue Comment", true, "Test", "0", "0", null, null);
@@ -211,7 +215,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, reviewResult.comments.size());
         Assert.assertEquals(1, reviewResult.labels.size());
         Assert.assertEquals(0, reviewResult.labels.get("Test").intValue());
-        Assert.assertEquals(ReviewInput.NotifyHandling.OWNER, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
                 "No Issues Header", "Some Issues Header", "Issue Comment", true, "Test", "1test", "-1test", "NONE", "ALL");
@@ -220,7 +224,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(1, reviewResult.comments.size());
         Assert.assertEquals(1, reviewResult.labels.size());
         Assert.assertEquals(0, reviewResult.labels.get("Test").intValue());
-        Assert.assertEquals(ReviewInput.NotifyHandling.ALL, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.ALL, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
                 "No Issues Header", "Some Issues Header", "Issue Comment", true, "Test", "1", "-1", null, null);
@@ -230,7 +234,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(0, reviewResult.comments.size());
         Assert.assertEquals(1, reviewResult.labels.size());
         Assert.assertEquals(+1, reviewResult.labels.get("Test").intValue());
-        Assert.assertEquals(ReviewInput.NotifyHandling.NONE, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.NONE, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
                 "No Issues Header", "Some Issues Header", "Issue Comment", true, "Test", "1", "-1", "OWNER_REVIEWERS", "ALL");
@@ -239,7 +243,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals("No Issues Header", reviewResult.message);
         Assert.assertEquals(0, reviewResult.comments.size());
         Assert.assertEquals(1, reviewResult.labels.size());
-        Assert.assertEquals(ReviewInput.NotifyHandling.OWNER_REVIEWERS, reviewResult.notify);
+        Assert.assertEquals(NotifyHandling.OWNER_REVIEWERS, reviewResult.notify);
         Assert.assertEquals(+1, reviewResult.labels.get("Test").intValue());
 
     }
@@ -291,7 +295,19 @@ public class SonarToGerritPublisherTest {
                 public DiffInfo diff(String base) throws RestApiException {
                     throw new UnsupportedOperationException("This is a dummy test class");
                 }
+
+                @Override
+                public DiffInfo diff(int parent) throws RestApiException {
+                    throw new UnsupportedOperationException("This is a dummy test class");
+                }
+
+                @Override
+                public DiffRequest diffRequest() throws RestApiException {
+                    throw new UnsupportedOperationException("This is a dummy test class");
+                }
+
             };
+
         }
 
         private DiffInfo generateDiffInfoByPath(String path) {
@@ -327,7 +343,6 @@ public class SonarToGerritPublisherTest {
             }
             return entry;
         }
-
 
         @Override
         public void delete() throws RestApiException {
@@ -428,6 +443,72 @@ public class SonarToGerritPublisherTest {
         public CommentApi comment(String id) throws RestApiException {
             throw new UnsupportedOperationException("This is a dummy test class");
         }
+
+        @Override
+        public Map<String, ActionInfo> actions() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public List<CommentInfo> commentsAsList() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public List<CommentInfo> draftsAsList() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public Map<String, FileInfo> files(int parentNum) throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public RevisionApi.MergeListRequest getMergeList() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public BinaryResult patch() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public BinaryResult patch(String path) throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public RobotCommentApi robotComment(String id) throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public List<RobotCommentInfo> robotCommentsAsList() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public BinaryResult submitPreview() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public SubmitType submitType() throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
+        @Override
+        public SubmitType testSubmitType(TestSubmitRuleInput in) throws RestApiException {
+            throw new UnsupportedOperationException("This is a dummy test class");
+        }
+
     }
 
 }


### PR DESCRIPTION
The latest release contains several API changes which require modification
of the SonarToGerritPublisher class.  In addition, the gerrit-rest-java-client
previously contained a bug which would always authenticate against the /login
page to obtain a session cookie.  When the sonar-gerrit-plugin uses a Gerrit
HTTP password for authentication, this will cause the LDAP account to become
locked due to invalid authentication attempts.

For details about the authentication bug see:
   https://github.com/uwolfer/gerrit-rest-java-client/issues/46