### PR TITLE
Fix issues map use revision filename

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -28,3 +28,6 @@ jenkins.plugin.review.sent=Review has been sent
 jenkins.plugin.connected.to.gerrit=Connected to Gerrit: server name: %s. Change Number: %s, PatchSetNumber: %s
 jenkins.plugin.report.loaded=Report has loaded and contains %s issues
 jenkins.plugin.getting.report=Getting Sonar Report from: %s
+jenkins.plugin.report.filtered.new=Report has filtered new and contains %s issues
+jenkins.plugin.report.filtered.files=Report has filtered files and contains %s issues
+jenkins.plugin.report.filtered.lines=Report has filtered lines and contains %s issues

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/config.jelly
@@ -150,5 +150,12 @@
                 </select>
             </f:entry>
         </f:section>
+
+        <f:section title="${%jenkins.plugin.settings.section.publish.build.result.name}">
+            <f:entry title="${%jenkins.plugin.settings.mark.failure}" field="markFailure"
+                     description="${%jenkins.plugin.settings.mark.failure.description}">
+                <f:checkbox default="true"/>
+            </f:entry>
+        </f:section>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/config.properties
@@ -47,5 +47,6 @@ OWNER=Owner
 OWNER_REVIEWERS=Owner and Reviewers
 ALL=All
 
-
-
+jenkins.plugin.settings.section.publish.build.result.name=Publish Build Result
+jenkins.plugin.settings.mark.failure=Mark result failure?
+jenkins.plugin.settings.mark.failure.description=Mark the build result failure if SonarQube violations found when checked

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/help-markFailure.html
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/help-markFailure.html
@@ -1,0 +1,4 @@
+<div>
+    Check if you want mark a build failed in case there are <b> SonarQube issues matching filter settings</b> found in particular commit.
+    If you want a build passed even there are  <b> SonarQube issues matching filter settings</b> found leave this control unchecked.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/help-markFailureIssuesFound.html
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher/help-markFailureIssuesFound.html
@@ -1,0 +1,4 @@
+<div>
+    Check if you want mark a build failed in case there are <b> SonarQube issues matching filter settings</b> found in particular commit.
+    If you want a build passed even there are  <b> SonarQube issues matching filter settings</b> found leave this control unchecked.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisherTest.java
@@ -42,35 +42,35 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(19, report.getIssues().size());
 
         // severity predicate
-        Iterable<Issue> issues = new SonarToGerritPublisher("", null, Severity.CRITICAL.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        Iterable<Issue> issues = new SonarToGerritPublisher("", null, Severity.CRITICAL.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(2, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.MAJOR.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.MAJOR.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(12, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(19, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.MINOR.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.MINOR.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(18, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.BLOCKER.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.BLOCKER.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(1, Sets.newHashSet(issues).size());
 
         // new issues only predicate
-        issues = new SonarToGerritPublisher("", null, Severity.CRITICAL.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.CRITICAL.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(0, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.MAJOR.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.MAJOR.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(1, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(1, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.MINOR.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.MINOR.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(1, Sets.newHashSet(issues).size());
 
-        issues = new SonarToGerritPublisher("", null, Severity.BLOCKER.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "").filterIssuesByPredicates(report.getIssues());
+        issues = new SonarToGerritPublisher("", null, Severity.BLOCKER.name(), true, true, "", "", "", false, "", "", true, "", "0", "0", "", "", true).filterIssuesByPredicates(report.getIssues());
         Assert.assertEquals(0, Sets.newHashSet(issues).size());
     }
 
@@ -132,7 +132,7 @@ public class SonarToGerritPublisherTest {
 
         SubJobConfig config1 = new SubJobConfig("testfolder1/", "report1.json");
         SubJobConfig config2 = new SubJobConfig("testfolder2/", "report2.json");
-        SonarToGerritPublisher sonarToGerritPublisher = new SonarToGerritPublisher("", Arrays.asList(config1, config2), Severity.INFO.name(), true, false, "", "", "",  false, "", "",true, "", "0", "0", "", "");
+        SonarToGerritPublisher sonarToGerritPublisher = new SonarToGerritPublisher("", Arrays.asList(config1, config2), Severity.INFO.name(), true, false, "", "", "",  false, "", "",true, "", "0", "0", "", "", true);
         String resourcePath = getClass().getClassLoader().getResource("filter.json").getPath();
         FilePath resourceFolder = new FilePath(new File(resourcePath).getParentFile());
         List<SonarToGerritPublisher.ReportInfo> reportInfos = sonarToGerritPublisher.readSonarReports(null, resourceFolder);//todo assert
@@ -181,7 +181,7 @@ public class SonarToGerritPublisherTest {
         RevisionApi revApi = new DummyRevisionApi(path2changedValues);
 
 
-        SonarToGerritPublisher builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "");
+        SonarToGerritPublisher builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false, "", "", "", false, "", "", true, "", "0", "0", "", "", true);
         builder.filterIssuesByChangedLines(multimap, revApi);
 
         // list of lines commented by sonar : 37, 54,81, 99, 106, 108, 122, 162
@@ -203,7 +203,7 @@ public class SonarToGerritPublisherTest {
         finalIssues.put("guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/PluginsManager.java", new DummyIssue());
         finalIssues.put("guice-bootstrap/src/main/java/com/magenta/guice/bootstrap/plugins/PluginsManager.java", new DummyIssue());
         SonarToGerritPublisher builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "+1", "-1", "NONE", "OWNER");
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "+1", "-1", "NONE", "OWNER", true);
         ReviewInput reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("Some Issues Header", reviewResult.message);
         Assert.assertEquals(1, reviewResult.comments.size());
@@ -212,7 +212,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", false, "Test", "1", "-1", null, null);
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", false, "Test", "1", "-1", null, null, true);
         reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("Some Issues Header", reviewResult.message);
         Assert.assertEquals(1, reviewResult.comments.size());
@@ -220,7 +220,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "0", "0", null, null);
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "0", "0", null, null, true);
         reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("Some Issues Header", reviewResult.message);
         Assert.assertEquals(1, reviewResult.comments.size());
@@ -229,7 +229,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(NotifyHandling.OWNER, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1test", "-1test", "NONE", "ALL");
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1test", "-1test", "NONE", "ALL", true);
         reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("Some Issues Header", reviewResult.message);
         Assert.assertEquals(1, reviewResult.comments.size());
@@ -238,7 +238,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(NotifyHandling.ALL, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1", "-1", null, null);
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1", "-1", null, null, true);
         finalIssues = LinkedListMultimap.create();
         reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("No Issues Header", reviewResult.message);
@@ -248,7 +248,7 @@ public class SonarToGerritPublisherTest {
         Assert.assertEquals(NotifyHandling.NONE, reviewResult.notify);
 
         builder = new SonarToGerritPublisher("", null, Severity.INFO.name(), true, false,
-                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1", "-1", "OWNER_REVIEWERS", "ALL");
+                "No Issues Header", "Some Issues Header", "Issue Comment", false, "", "", true, "Test", "1", "-1", "OWNER_REVIEWERS", "ALL", true);
         finalIssues = LinkedListMultimap.create();
         reviewResult = builder.getReviewResult(finalIssues);
         Assert.assertEquals("No Issues Header", reviewResult.message);


### PR DESCRIPTION
the key of map<file, issue> generate from sonar-report.json has the format like \<component path\>/src/main/...
sometimes, when the project is big, the revision filename from girret is like \<project path\>/\<component path\>/src/main/....

in this condition, we can't filter issues exactly match the key with the revision filename.

this patch fix the bug.  [JENKINS-37765](https://issues.jenkins-ci.org/browse/JENKINS-37765)