### PR TITLE
JENKINS-58279 Fixes for java11 compatibility, Arrays.asList().toArray…() definition was changed to return Object[] in java 9.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -109,7 +109,7 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
 
         //load revision info
         GerritTrigger trigger = GerritTrigger.getTrigger(run.getParent());
-        Map<String, String> envVars = getEnvVars(run, listener, (String[]) GerritConnectionInfo.REQUIRED_VARS.toArray());
+        Map<String, String> envVars = getEnvVars(run, listener, GerritConnectionInfo.REQUIRED_VARS);
         GerritConnectionInfo connectionInfo = new GerritConnectionInfo(envVars, trigger, authConfig);
         try {
             GerritConnector connector = new GerritConnector(connectionInfo);
@@ -162,7 +162,7 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
         return sonarConnector.getReportData(issuesToComment);
     }
 
-    private Map<String, String> getEnvVars(Run<?, ?> run, TaskListener listener, String... varNames) throws IOException, InterruptedException {
+    private Map<String, String> getEnvVars(Run<?, ?> run, TaskListener listener, List<String> varNames) throws IOException, InterruptedException {
         Map<String, String> envVars = new HashMap<>();
         for (String varName : varNames) {
             envVars.put(varName, getEnvVar(run, listener, varName));


### PR DESCRIPTION
[JENKINS-58279](https://issues.jenkins-ci.org/browse/JENKINS-58279)

Arrays.asList().toArray…() definition was changed to return Object[] in java 9 so the plugin fails at runtime on this call.