### PR TITLE
JENKINS-64365: Support SonarQube 7.7 with Pull Request Analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
-        <relativePath />
+        <version>4.4</version>
+        <relativePath/>
     </parent>
 
     <artifactId>sonar-gerrit</artifactId>
@@ -15,16 +16,17 @@
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>1.625.3</jenkins.version>
+        <!--        <jenkins.version>1.625.3</jenkins.version>-->
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-        <java.level>7</java.level>
+        <java.level>8</java.level>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+        <!--        <jenkins-test-harness.version>2.13</jenkins-test-harness.version>-->
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
         -->
+        <jersey.version>2.31</jersey.version>
     </properties>
 
     <name>Sonar Gerrit Plugin</name>
@@ -89,18 +91,21 @@
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>1.0</compatibleSinceVersion>
+                    <!-- Otherwise classes are loaded from Guava 11 by Jenkins WAR -->
+                    <maskClasses>com.google.common.</maskClasses>
+                    <minimumJavaVersion>${java.level}</minimumJavaVersion>
                 </configuration>
             </plugin>
             <!--<plugin>-->
-                <!--<artifactId>maven-release-plugin</artifactId>-->
-                <!--<version>2.5.3</version>-->
-                <!--<dependencies>-->
-                    <!--<dependency>-->
-                        <!--<groupId>org.apache.maven.scm</groupId>-->
-                        <!--<artifactId>maven-scm-provider-gitexe</artifactId>-->
-                        <!--<version>2.5</version>-->
-                    <!--</dependency>-->
-                <!--</dependencies>-->
+            <!--<artifactId>maven-release-plugin</artifactId>-->
+            <!--<version>2.5.3</version>-->
+            <!--<dependencies>-->
+            <!--<dependency>-->
+            <!--<groupId>org.apache.maven.scm</groupId>-->
+            <!--<artifactId>maven-scm-provider-gitexe</artifactId>-->
+            <!--<version>2.5</version>-->
+            <!--</dependency>-->
+            <!--</dependencies>-->
             <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -136,36 +141,112 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <!-- managed to solve requireUpperBoundDeps Rule issues -->
+        <dependencies>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>3.6</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-step-api</artifactId>
+                <version>2.22</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>2.40</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-support</artifactId>
+                <version>3.5</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.14</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.6.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.71</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- PLUGIN DEPENDENCIES -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.2</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
             <artifactId>gerrit-trigger</artifactId>
-            <version>2.16.0</version>
+            <version>2.30.5</version>
         </dependency>
+        <!-- to replace makros like ${GERRIT_CHANGE_NUMBER} -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>2.12</version>
+        </dependency>
+        <!-- to reuse Sonar Installations with credentials from this plugin -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>sonar</artifactId>
+            <version>2.12</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>com.urswolfer.gerrit.client.rest</groupId>
             <artifactId>gerrit-rest-java-client</artifactId>
-            <version>0.8.11</version>
+            <version>0.9.2</version>
+        </dependency>
+
+        <!-- JERSEY CLIENT -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-binding</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -240,7 +240,6 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
      * Descriptor for {@link SonarToGerritPublisher}. Used as a singleton.
      * The class is marked as public so that it can be accessed from views.
      * <p>
-     * <p>
      * See <tt>src/main/resources/hudson/plugins/hello_world/SonarToGerritBuilder/*.jelly</tt>
      * for the actual HTML fragment for the configuration screen.
      */

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -126,7 +126,7 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-        LOGGER.info("Starting Sonar to Gerrit Publisher with analysis type " + inspectionConfig.getAnalysisType());
+        TaskListenerLogger.logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.sonar.start", inspectionConfig.getAnalysisType());
 
         //load inspection report
         SonarConnector sonarConnector = new SonarConnector(run, listener, inspectionConfig);

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -1,19 +1,18 @@
 package org.jenkinsci.plugins.sonargerrit;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Multimap;
-import com.google.gerrit.extensions.api.changes.NotifyHandling;
-import com.google.gerrit.extensions.api.changes.ReviewInput;
-import com.google.gerrit.extensions.restapi.RestApiException;
-import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
-import hudson.*;
-import hudson.model.*;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.BuildStepMonitor;
-import hudson.tasks.Publisher;
-import jenkins.tasks.SimpleBuildStep;
+import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+
+import javax.annotation.Nonnull;
+
 import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.sonargerrit.config.*;
+import org.jenkinsci.plugins.sonargerrit.config.GerritAuthenticationConfig;
+import org.jenkinsci.plugins.sonargerrit.config.InspectionConfig;
+import org.jenkinsci.plugins.sonargerrit.config.IssueFilterConfig;
+import org.jenkinsci.plugins.sonargerrit.config.NotificationConfig;
+import org.jenkinsci.plugins.sonargerrit.config.ReviewConfig;
+import org.jenkinsci.plugins.sonargerrit.config.ScoreConfig;
+import org.jenkinsci.plugins.sonargerrit.config.SonarInstallationReader;
+import org.jenkinsci.plugins.sonargerrit.config.SubJobConfig;
 import org.jenkinsci.plugins.sonargerrit.filter.IssueFilter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.Severity;
@@ -28,13 +27,37 @@ import org.jenkinsci.plugins.sonargerrit.util.Localization;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Multimap;
+import com.google.gerrit.extensions.api.changes.NotifyHandling;
+import com.google.gerrit.extensions.api.changes.ReviewInput;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.sonar.SonarInstallation;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import jenkins.tasks.SimpleBuildStep;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -103,8 +126,10 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        LOGGER.info("Starting Sonar to Gerrit Publisher with analysis type " + inspectionConfig.getAnalysisType());
+
         //load inspection report
-        SonarConnector sonarConnector = new SonarConnector(listener, inspectionConfig);
+        SonarConnector sonarConnector = new SonarConnector(run, listener, inspectionConfig);
         sonarConnector.readSonarReports(filePath);
 
         //load revision info
@@ -139,15 +164,23 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
                 TaskListenerLogger.logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.issues.to.score", file2issuesToScore.entries().size());
             }
 
+            String serverUrl;
+            if (inspectionConfig.getAnalysisType() == InspectionConfig.DescriptorImpl.AnalysisType.PREVIEW_MODE) {
+                serverUrl = inspectionConfig.getServerURL();
+            } else {
+                SonarInstallation sonarInstallation = SonarInstallationReader
+                        .getSonarInstallation(inspectionConfig.getSonarInstallationName());
+                serverUrl = sonarInstallation.getServerUrl();
+            }
+
             //send review
             ReviewInput reviewInput = new GerritReviewBuilder(file2issuesToComment, file2issuesToScore,
-                    reviewConfig, scoreConfig, notificationConfig, inspectionConfig
-            ).buildReview();
+                    reviewConfig, scoreConfig, notificationConfig, serverUrl).buildReview();
             revisionInfo.sendReview(reviewInput);
 
             TaskListenerLogger.logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.review.sent");
         } catch (RestApiException e) {
-            LOGGER.log(Level.SEVERE, "Unable to post review: " + e.getMessage(), e);
+            LOGGER.log(Level.SEVERE, e, () -> "Unable to post review: " + e.getMessage());
             throw new AbortException("Unable to post review: " + e.getMessage());
         } catch (NullPointerException | IllegalArgumentException | IllegalStateException e) {
             throw new AbortException(e.getMessage());
@@ -222,6 +255,8 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
         public static final String PROJECT_PATH = "";
         public static final String SONAR_REPORT_PATH = "target/sonar/sonar-report.json";
         public static final String SONAR_URL = "http://localhost:9000";
+        public static final String SONAR_PULLREQUEST_KEY = "${GERRIT_CHANGE_NUMBER}";
+
         public static final String DEFAULT_INSPECTION_CONFIG_TYPE = InspectionConfig.DescriptorImpl.BASE_TYPE;
         public static final boolean AUTO_MATCH_INSPECTION_AND_REVISION_PATHS = false;
 
@@ -240,6 +275,7 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
         public static final boolean CHANGED_LINES_ONLY = false;
 
         public static final int DEFAULT_SCORE = 0;
+
 
         /**
          * In order to load the persisted global configuration, you have to

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/SonarToGerritPublisher.java
@@ -180,7 +180,6 @@ public class SonarToGerritPublisher extends Publisher implements SimpleBuildStep
 
             TaskListenerLogger.logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.review.sent");
         } catch (RestApiException e) {
-            LOGGER.log(Level.SEVERE, e, () -> "Unable to post review: " + e.getMessage());
             throw new AbortException("Unable to post review: " + e.getMessage());
         } catch (NullPointerException | IllegalArgumentException | IllegalStateException e) {
             throw new AbortException(e.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -91,7 +92,7 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
     @DataBoundSetter
     public void setServerURL(String serverURL) {
-        this.serverURL = MoreObjects.firstNonNull(Util.fixEmptyAndTrim(serverURL), DescriptorImpl.SONAR_URL);
+        this.serverURL = Optional.ofNullable(serverURL).map(Util::fixEmptyAndTrim).orElse(DescriptorImpl.SONAR_URL);
     }
 
     public SubJobConfig getBaseConfig() {

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
@@ -234,21 +234,19 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         /**
          * Is only called once, filtering is done in Frontend by a Combo Box
          *
-         * @param value component to search for
          * @param sonarInstallationName  specifies the SonarQube server where the components are fetched from
          * @param analysisType only for Analysis Type.PULL_REQUEST the components are inserted into the model's list of components
          * @return model containing a list of components matching the given component name
          * @throws AbortException if Sonar installation cannot be found
          */
         @SuppressWarnings("unused")
-        public ComboBoxModel doFillComponentItems(@QueryParameter String value, @QueryParameter String sonarInstallationName,
+        public ComboBoxModel doFillComponentItems(@QueryParameter String sonarInstallationName,
                 @QueryParameter AnalysisType analysisType) throws AbortException {
             if (analysisType == AnalysisType.PULL_REQUEST) {
                 ComponentSearchResult componentSearchResult;
 
                 try (SonarClient sonarClient = SonarUtil.getSonarClient(sonarInstallationName)) {
-                    String componentKey = SonarUtil.isolateComponentKey(value);
-                    componentSearchResult = sonarClient.fetchComponent(componentKey);
+                    componentSearchResult = sonarClient.fetchComponents(null);
                 }
 
                 return new ComboBoxModel(componentSearchResult.getComponents().stream()
@@ -265,7 +263,7 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
             if (analysisType == AnalysisType.PULL_REQUEST) {
                 try (SonarClient sonarClient = SonarUtil.getSonarClient(sonarInstallationName)) {
                     String componentKey = SonarUtil.isolateComponentKey(value);
-                    ComponentSearchResult componentSearchResult = sonarClient.fetchComponent(componentKey);
+                    ComponentSearchResult componentSearchResult = sonarClient.fetchComponents(componentKey);
 
                     if (componentSearchResult.getPaging().getTotal() == 1) {
                         Component component = componentSearchResult.getComponents().get(0);

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
@@ -1,23 +1,43 @@
 package org.jenkinsci.plugins.sonargerrit.config;
 
-import com.google.common.base.MoreObjects;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.Extension;
-import hudson.Util;
-import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import hudson.util.FormValidation;
+import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+
+import javax.annotation.Nonnull;
+
 import org.jenkinsci.plugins.sonargerrit.SonarToGerritPublisher;
+import org.jenkinsci.plugins.sonargerrit.sonar.SonarClient;
+import org.jenkinsci.plugins.sonargerrit.sonar.SonarUtil;
+import org.jenkinsci.plugins.sonargerrit.sonar.dto.Component;
+import org.jenkinsci.plugins.sonargerrit.sonar.dto.ComponentSearchResult;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.Nonnull;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+import com.google.common.base.MoreObjects;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.plugins.sonar.SonarGlobalConfiguration;
+import hudson.plugins.sonar.SonarInstallation;
+import hudson.util.ComboBoxModel;
+import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -26,8 +46,12 @@ import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
  * $Id$
  */
 public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> {
-    @Nonnull
+    private DescriptorImpl.AnalysisType analysisType;
+
     private String serverURL = DescriptorImpl.SONAR_URL;
+
+    private String pullrequestKey;
+    private String component;
 
     private SubJobConfig baseConfig;
 
@@ -36,17 +60,21 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
     private String type;
 
+    private String sonarInstallationName;
+
     @DataBoundConstructor
     public InspectionConfig() {
-        this(DescriptorImpl.SONAR_URL, null, null, DescriptorImpl.BASE_TYPE); // set default values
+        this(DescriptorImpl.SONAR_URL, null, null, DescriptorImpl.BASE_TYPE, DescriptorImpl.AnalysisType.PREVIEW_MODE); // set default values
     }
 
-    @SuppressFBWarnings(value="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR") // subJobConfigs is initialized in setter
-    private InspectionConfig(@Nonnull String serverURL, SubJobConfig baseConfig, List<SubJobConfig> subJobConfigs, String type) {
+    @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR") // subJobConfigs is initialized in setter
+    private InspectionConfig(String serverURL, SubJobConfig baseConfig, List<SubJobConfig> subJobConfigs, String type,
+            DescriptorImpl.AnalysisType analysisType) {
         setServerURL(serverURL);
         setBaseConfig(baseConfig);
         setSubJobConfigs(subJobConfigs);
         setType(type);
+        setAnalysisType(analysisType);
     }
 
     @Override
@@ -54,13 +82,12 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         return new DescriptorImpl();
     }
 
-    @Nonnull
     public String getServerURL() {
         return serverURL;
     }
 
     @DataBoundSetter
-    public void setServerURL(@Nonnull String serverURL) {
+    public void setServerURL(String serverURL) {
         this.serverURL = MoreObjects.firstNonNull(Util.fixEmptyAndTrim(serverURL), DescriptorImpl.SONAR_URL);
     }
 
@@ -96,6 +123,16 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         return type;
     }
 
+    public DescriptorImpl.AnalysisType getAnalysisType() {
+        // default of field and c'tor has no effect, so do it here
+        return analysisType != null ? analysisType : DescriptorImpl.AnalysisType.PREVIEW_MODE;
+    }
+
+    @DataBoundSetter
+    public void setAnalysisType(DescriptorImpl.AnalysisType analysisType) {
+        this.analysisType = analysisType;
+    }
+
     public boolean isMultiConfigMode() {
         return isType(DescriptorImpl.MULTI_TYPE);
     }
@@ -113,7 +150,7 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
     @DataBoundSetter
     public void setSubJobConfigs(Collection<SubJobConfig> subJobConfigs) {
-        if (subJobConfigs != null && subJobConfigs.size() > 0) {
+        if (subJobConfigs != null && !subJobConfigs.isEmpty()) {
             this.subJobConfigs = new LinkedList<>(subJobConfigs);
         } else {
             this.subJobConfigs = new LinkedList<>();
@@ -125,9 +162,50 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         return isAutoMatch();
     }
 
+    public String getPullrequestKey() {
+        return pullrequestKey;
+    }
+
+    @DataBoundSetter
+    public void setPullrequestKey(String pullrequestKey) {
+        this.pullrequestKey = pullrequestKey;
+    }
+
+    public String getComponent() {
+        return component;
+    }
+
+    @DataBoundSetter
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public List<SonarInstallation> getSonarInstallations() {
+        SonarGlobalConfiguration sonarGlobalConfiguration = GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
+        return sonarGlobalConfiguration != null ? Arrays.asList(sonarGlobalConfiguration.getInstallations()) : null;
+    }
+
+    @DataBoundSetter
+    public void setSonarInstallationName(String sonarInstallationName) {
+        this.sonarInstallationName = sonarInstallationName;
+    }
+
+    public String getSonarInstallationName() {
+        return sonarInstallationName;
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<InspectionConfig> {
+        public enum AnalysisType {
+            PREVIEW_MODE,
+            PULL_REQUEST
+        }
+
+        public static final String ANALYSIS_TYPE_PREVIEW_MODE = AnalysisType.PREVIEW_MODE.name();
+        public static final String ANALYSIS_TYPE_PULL_REQUEST = AnalysisType.PULL_REQUEST.name();
+
         public static final String SONAR_URL = SonarToGerritPublisher.DescriptorImpl.SONAR_URL;
+        public static final String SONAR_PULLREQUEST_KEY = SonarToGerritPublisher.DescriptorImpl.SONAR_PULLREQUEST_KEY;
         public static final String BASE_TYPE = "base";
         public static final String MULTI_TYPE = "multi";
         public static final String DEFAULT_INSPECTION_CONFIG_TYPE = SonarToGerritPublisher.DescriptorImpl.DEFAULT_INSPECTION_CONFIG_TYPE;
@@ -135,17 +213,6 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
         private static final Set<String> ALLOWED_TYPES = new HashSet<>(Arrays.asList(BASE_TYPE, MULTI_TYPE));
 
-        /**
-         * Performs on-the-fly validation of the form field 'serverURL'.
-         *
-         * @param value This parameter receives the value that the user has typed.
-         *
-         * @return Indicates the outcome of the validation. This is sent to the browser.
-         * <p>
-         * Note that returning {@link FormValidation#error(String)} does not
-         * prevent the form from being saved. It just means that a message
-         * will be displayed to the user.
-         */
         @SuppressWarnings(value = "unused")
         public FormValidation doCheckServerURL(@QueryParameter String value) {
             if (Util.fixEmptyAndTrim(value) == null) {
@@ -160,8 +227,57 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
         }
 
+        /**
+         * Is only called once, filtering is done in Frontend by Combo Box
+         */
+        @SuppressWarnings("unused")
+        public ComboBoxModel doFillComponentItems(@QueryParameter String value, @QueryParameter String sonarInstallationName,
+                @QueryParameter AnalysisType analysisType) throws AbortException {
+            if (analysisType == AnalysisType.PULL_REQUEST) {
+                SonarClient sonarClient = SonarUtil.getSonarClient(sonarInstallationName);
+                ComponentSearchResult componentSearchResult = sonarClient.fetchComponent(value);
+                return new ComboBoxModel(componentSearchResult.getComponents().stream()
+                        .map(c -> c.getName() + " (" + c.getKey() + ")")
+                        .collect(Collectors.toList()));
+            } else {
+                return new ComboBoxModel();
+            }
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckComponent(@QueryParameter String value, @QueryParameter String sonarInstallationName,
+                @QueryParameter AnalysisType analysisType) throws AbortException {
+            if (analysisType == AnalysisType.PULL_REQUEST) {
+                SonarClient sonarClient = SonarUtil.getSonarClient(sonarInstallationName);
+                String componentKey = SonarUtil.isolateComponentKey(value);
+                ComponentSearchResult componentSearchResult = sonarClient.fetchComponent(componentKey);
+
+                if (componentSearchResult.getPaging().getTotal() == 1) {
+                    Component component = componentSearchResult.getComponents().get(0);
+                    if (!Objects.equals(componentKey, component.getKey())) {
+                        return FormValidation
+                                .error("Ambiguous project key '" + value + "'. Did you mean '" + component.getKey() + "'?");
+                    } else {
+                        return FormValidation
+                                .ok(component.getName() + ": " + sonarClient.getServerUrl() + "dashboard?id=" + component
+                                        .getKey());
+                    }
+                } else if (componentSearchResult.getPaging().getTotal() > 1) {
+                    return FormValidation
+                            .error("Multiple results found for '" + componentKey + "' on " + sonarClient.getServerUrl());
+                } else {
+                    return FormValidation.error("'" + componentKey + "' could not be found on " + sonarClient.getServerUrl());
+                }
+            } else {
+                return FormValidation.ok();
+            }
+        }
+
+        @Override
+        @Nonnull
         public String getDisplayName() {
             return "InspectionConfig";
         }
     }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
@@ -48,9 +48,11 @@ import jenkins.model.GlobalConfiguration;
 public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> {
     private DescriptorImpl.AnalysisType analysisType;
 
+    @Nonnull
     private String serverURL = DescriptorImpl.SONAR_URL;
 
-    private String pullrequestKey;
+    private String pullRequestKey;
+
     private String component;
 
     private SubJobConfig baseConfig;
@@ -82,6 +84,7 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         return new DescriptorImpl();
     }
 
+    @Nonnull
     public String getServerURL() {
         return serverURL;
     }
@@ -149,7 +152,7 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
     }
 
     @DataBoundSetter
-    public void setSubJobConfigs(Collection<SubJobConfig> subJobConfigs) {
+    public final void setSubJobConfigs(Collection<SubJobConfig> subJobConfigs) {
         if (subJobConfigs != null && !subJobConfigs.isEmpty()) {
             this.subJobConfigs = new LinkedList<>(subJobConfigs);
         } else {
@@ -162,13 +165,13 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         return isAutoMatch();
     }
 
-    public String getPullrequestKey() {
-        return pullrequestKey;
+    public String getPullRequestKey() {
+        return pullRequestKey;
     }
 
     @DataBoundSetter
-    public void setPullrequestKey(String pullrequestKey) {
-        this.pullrequestKey = pullrequestKey;
+    public void setPullRequestKey(String pullRequestKey) {
+        this.pullRequestKey = pullRequestKey;
     }
 
     public String getComponent() {
@@ -228,12 +231,12 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
         }
 
         /**
-         * Is only called once, filtering is done in Frontend by Combo Box
+         * Is only called once, filtering is done in Frontend by a Combo Box
          *
          * @param value component to search for
-         * @param sonarInstallationName sonarInstallationName which chooses the SonarQube server where the components are fetched
-         * @param analysisType only for AnalysisType.PULL_REQUEST components are filled
-         * @return list of components matching value
+         * @param sonarInstallationName  specifies the SonarQube server where the components are fetched from
+         * @param analysisType only for Analysis Type.PULL_REQUEST the components are inserted into the model's list of components
+         * @return model containing a list of components matching the given component name
          * @throws AbortException if Sonar installation cannot be found
          */
         @SuppressWarnings("unused")
@@ -241,7 +244,8 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
                 @QueryParameter AnalysisType analysisType) throws AbortException {
             if (analysisType == AnalysisType.PULL_REQUEST) {
                 SonarClient sonarClient = SonarUtil.getSonarClient(sonarInstallationName);
-                ComponentSearchResult componentSearchResult = sonarClient.fetchComponent(value);
+                String componentKey = SonarUtil.isolateComponentKey(value);
+                ComponentSearchResult componentSearchResult = sonarClient.fetchComponent(componentKey);
                 return new ComboBoxModel(componentSearchResult.getComponents().stream()
                         .map(c -> c.getName() + " (" + c.getKey() + ")")
                         .collect(Collectors.toList()));

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig.java
@@ -229,6 +229,12 @@ public class InspectionConfig extends AbstractDescribableImpl<InspectionConfig> 
 
         /**
          * Is only called once, filtering is done in Frontend by Combo Box
+         *
+         * @param value component to search for
+         * @param sonarInstallationName sonarInstallationName which chooses the SonarQube server where the components are fetched
+         * @param analysisType only for AnalysisType.PULL_REQUEST components are filled
+         * @return list of components matching value
+         * @throws AbortException if Sonar installation cannot be found
          */
         @SuppressWarnings("unused")
         public ComboBoxModel doFillComponentItems(@QueryParameter String value, @QueryParameter String sonarInstallationName,

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/ReviewConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/ReviewConfig.java
@@ -7,7 +7,6 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import org.jenkinsci.plugins.sonargerrit.SonarToGerritPublisher;
-import org.jenkinsci.plugins.sonargerrit.util.DataHelper;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -154,6 +153,7 @@ public class ReviewConfig extends AbstractDescribableImpl<ReviewConfig> {
             return FormValidation.validateRequired(value);
         }
 
+        @Override
         public String getDisplayName() {
             return "ReviewConfig";
         }

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.sonargerrit.config;
+
+import java.util.Arrays;
+
+import hudson.AbortException;
+import hudson.plugins.sonar.SonarGlobalConfiguration;
+import hudson.plugins.sonar.SonarInstallation;
+import jenkins.model.GlobalConfiguration;
+
+public class SonarInstallationReader {
+    public static SonarInstallation getSonarInstallation(String sonarInstallationName) throws AbortException {
+        SonarGlobalConfiguration sonarGlobalConfiguration = GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
+
+        if (sonarGlobalConfiguration == null) {
+            throw new AbortException("Missing SonarGlobalConfiguration -> Install SonarQube Scanner for Jenkins: "
+                    + "https://plugins.jenkins.io/sonar/");
+        }
+
+        SonarInstallation[] installations = sonarGlobalConfiguration.getInstallations();
+
+        if (installations.length == 0) {
+            throw new AbortException("No SonarQube server found -> Add one in Jenkins system configuration - SonarQube servers");
+        }
+
+        return Arrays.stream(installations)
+                .filter(installation -> installation.getName().equals(sonarInstallationName)).findFirst()
+                .orElseThrow(() -> new AbortException("SonarQube '" + sonarInstallationName + "' not found -> Add it in Jenkins"
+                        + " system configuration - SonarQube servers"));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.sonargerrit.config;
 
+import org.jenkinsci.plugins.sonargerrit.util.Localization;
+
 import java.util.Arrays;
 
 import hudson.AbortException;
@@ -14,19 +16,18 @@ public class SonarInstallationReader {
         SonarGlobalConfiguration sonarGlobalConfiguration = GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
 
         if (sonarGlobalConfiguration == null) {
-            throw new AbortException("Missing SonarGlobalConfiguration -> Install SonarQube Scanner for Jenkins: "
-                    + "https://plugins.jenkins.io/sonar/");
+            throw new AbortException(Localization.getLocalized("jenkins.plugin.error.sonar.config.missing"));
         }
 
         SonarInstallation[] installations = sonarGlobalConfiguration.getInstallations();
 
         if (installations.length == 0) {
-            throw new AbortException("No SonarQube server found -> Add one in Jenkins system configuration - SonarQube servers");
+            throw new AbortException(Localization.getLocalized("jenkins.plugin.error.sonar.server.missing"));
         }
 
         return Arrays.stream(installations)
                 .filter(installation -> installation.getName().equals(sonarInstallationName)).findFirst()
-                .orElseThrow(() -> new AbortException("SonarQube '" + sonarInstallationName + "' not found -> Add it in Jenkins"
-                        + " system configuration - SonarQube servers"));
+                .orElseThrow(() ->
+                        new AbortException(Localization.getLocalized("jenkins.plugin.error.sonar.server.notfound")));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/config/SonarInstallationReader.java
@@ -8,6 +8,8 @@ import hudson.plugins.sonar.SonarInstallation;
 import jenkins.model.GlobalConfiguration;
 
 public class SonarInstallationReader {
+    private SonarInstallationReader() {}
+
     public static SonarInstallation getSonarInstallation(String sonarInstallationName) throws AbortException {
         SonarGlobalConfiguration sonarGlobalConfiguration = GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
 

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Component.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Component.java
@@ -47,6 +47,21 @@ public class Component {
         return status;
     }
 
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setModuleKey(String moduleKey) {
+        this.moduleKey = moduleKey;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
@@ -1,9 +1,10 @@
 package org.jenkinsci.plugins.sonargerrit.inspection.entity;
 
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.json.bind.annotation.JsonbDateFormat;
 
 import java.util.Date;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -60,6 +61,7 @@ public class Issue {
 
     @SuppressWarnings("unused")
     @SuppressFBWarnings ("UWF_UNWRITTEN_FIELD")
+    @JsonbDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
     private Date creationDate;
 
     public String getKey() {
@@ -94,8 +96,48 @@ public class Issue {
         return isNew != null && isNew;
     }
 
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public void setSeverity(Severity severity) {
+        this.severity = severity;
+    }
+
+    public void setRule(String rule) {
+        this.rule = rule;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void setNew(Boolean aNew) {
+        isNew = aNew;
+    }
+
+    public Boolean getNew() {
+        return isNew;
+    }
+
     public Date getCreationDate() {
         return new Date(creationDate.getTime());
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = new Date(creationDate.getTime());
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
@@ -125,11 +125,11 @@ public class Issue {
     }
 
     public void setNew(Boolean aNew) {
-        isNew = aNew;
+        this.isNew = aNew;
     }
 
     public Boolean getNew() {
-        return isNew;
+        return this.isNew;
     }
 
     public Date getCreationDate() {

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Issue.java
@@ -128,16 +128,12 @@ public class Issue {
         this.isNew = aNew;
     }
 
-    public Boolean getNew() {
-        return this.isNew;
-    }
-
     public Date getCreationDate() {
-        return new Date(creationDate.getTime());
+        return creationDate == null ? null : new Date(creationDate.getTime());
     }
 
     public void setCreationDate(Date creationDate) {
-        this.creationDate = new Date(creationDate.getTime());
+        this.creationDate = creationDate == null ? null : new Date(creationDate.getTime());
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/IssueAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/IssueAdapter.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.sonargerrit.inspection.entity;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 /**

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/IssueAdapter.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/IssueAdapter.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.sonargerrit.inspection.entity;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 
 /**

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Report.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/entity/Report.java
@@ -44,6 +44,26 @@ public class Report  {
         return users;
     }
 
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setIssues(List<Issue> issues) {
+        this.issues = issues;
+    }
+
+    public void setComponents(List<Component> components) {
+        this.components = components;
+    }
+
+    public void setRules(List<Rule> rules) {
+        this.rules = rules;
+    }
+
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
+
     @Override
     public String toString() {
         return "Report{" +

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnector.java
@@ -16,6 +16,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -40,7 +41,7 @@ public class SonarConnector implements InspectionReportAdapter {
 
     private static final Logger LOGGER = Logger.getLogger(SonarConnector.class.getName());
 
-    private static final int SECONDS_TO_WAIT = 15;
+    private static final Duration SECONDS_TO_WAIT = Duration.ofSeconds(15);
 
     private final Run<?, ?> run;
 
@@ -91,7 +92,7 @@ public class SonarConnector implements InspectionReportAdapter {
         StringCredentials credentials = sonarInstallation.getCredentials(run);
 
         TaskListenerLogger.logMessage(listener, LOGGER, Level.FINE, "jenkins.plugin.sonar.issues.wait", SECONDS_TO_WAIT);
-        Thread.sleep(SECONDS_TO_WAIT * 1000);
+        Thread.sleep(SECONDS_TO_WAIT.getSeconds() * 1000);
 
         try (SonarClient sonarClient = new SonarClient(sonarInstallation, credentials, listener)) {
             Report report = sonarClient.fetchIssues(

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnector.java
@@ -1,16 +1,19 @@
 package org.jenkinsci.plugins.sonargerrit.inspection.sonarqube;
 
-import com.google.common.collect.Multimap;
-import hudson.AbortException;
-import hudson.FilePath;
-import hudson.model.TaskListener;
+import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.sonargerrit.TaskListenerLogger;
 import org.jenkinsci.plugins.sonargerrit.config.InspectionConfig;
+import org.jenkinsci.plugins.sonargerrit.config.SonarInstallationReader;
 import org.jenkinsci.plugins.sonargerrit.config.SubJobConfig;
 import org.jenkinsci.plugins.sonargerrit.inspection.InspectionReportAdapter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.Report;
-import org.jenkinsci.plugins.sonargerrit.util.Localization;
+import org.jenkinsci.plugins.sonargerrit.sonar.SonarClient;
+import org.jenkinsci.plugins.sonargerrit.sonar.SonarUtil;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,7 +21,13 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.jenkinsci.plugins.sonargerrit.util.Localization.getLocalized;
+import com.google.common.collect.Multimap;
+
+import hudson.AbortException;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.sonar.SonarInstallation;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -31,43 +40,67 @@ public class SonarConnector implements InspectionReportAdapter {
 
     private static final Logger LOGGER = Logger.getLogger(SonarConnector.class.getName());
 
-    private TaskListener listener;
-    private InspectionReport report;
-    private InspectionConfig inspectionConfig;
+    private final Run<?, ?> run;
+    private final TaskListener listener;
+    private final InspectionConfig inspectionConfig;
 
-    public SonarConnector(TaskListener listener, InspectionConfig inspectionConfig) {
+    private InspectionReport inspectionReport;
+
+    public SonarConnector(Run<?, ?> run, TaskListener listener, InspectionConfig inspectionConfig) {
+        this.run = run;
         this.inspectionConfig = inspectionConfig;
         this.listener = listener;
     }
 
-    public void readSonarReports(FilePath workspace) throws IOException,
-            InterruptedException {
-        List<ReportInfo> reports = new ArrayList<ReportInfo>();
-        for (SubJobConfig subJobConfig : inspectionConfig.getAllSubJobConfigs()) {
-            Report report = readSonarReport(workspace, subJobConfig.getSonarReportPath());
-            if (report == null) {  //todo fail all? skip errors?
-                TaskListenerLogger.logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.path.no.project.config.available");
-                throw new AbortException(getLocalized("jenkins.plugin.error.path.no.project.config.available"));
+    public void readSonarReports(FilePath workspace) throws IOException, InterruptedException {
+        List<ReportInfo> reports = new ArrayList<>();
+
+        if (inspectionConfig.getAnalysisType() == InspectionConfig.DescriptorImpl.AnalysisType.PULL_REQUEST) {
+            SonarInstallation sonarInstallation = SonarInstallationReader.getSonarInstallation(inspectionConfig.getSonarInstallationName());
+            StringCredentials credentials = sonarInstallation.getCredentials(run);
+
+            SonarClient sonarClient = new SonarClient(sonarInstallation, credentials);
+            try {
+                LOGGER.info("Sonar report processing can take some time, so wait 5 seconds ...");
+                Thread.sleep(5000);
+
+                Report report = sonarClient.fetchIssues(
+                        SonarUtil.isolateComponentKey(inspectionConfig.getComponent()),
+                        TokenMacro.expandAll(run, workspace, listener, inspectionConfig.getPullrequestKey()));
+                reports.add(new ReportInfo(new SubJobConfig(), report));
+            } catch (MacroEvaluationException e) {
+                throw new AbortException(e.getMessage());
             }
-            reports.add(new ReportInfo(subJobConfig, report));
+        } else {
+            for (SubJobConfig subJobConfig : inspectionConfig.getAllSubJobConfigs()) {
+                Report report = readSonarReport(workspace, subJobConfig.getSonarReportPath());
+
+                if (report == null) {  //tod fail all? skip errors?
+                    TaskListenerLogger
+                            .logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.path.no.project.config.available");
+                    throw new AbortException(getLocalized("jenkins.plugin.error.path.no.project.config.available"));
+                }
+                reports.add(new ReportInfo(subJobConfig, report));
+            }
         }
-        report = new InspectionReport(reports);
+
+        inspectionReport = new InspectionReport(reports);
     }
 
     public Multimap<String, IssueAdapter> getReportData() {
-        return report.asMultimap(getIssues());
+        return inspectionReport.asMultimap(getIssues());
     }
 
     public Multimap<String, IssueAdapter> getReportData(Iterable<IssueAdapter> issues) {
-        return report.asMultimap(issues);
+        return inspectionReport.asMultimap(issues);
     }
 
     public List<IssueAdapter> getIssues() {
-        return report.getIssuesList();
+        return inspectionReport.getIssuesList();
     }
 
     Report getRawReport(SubJobConfig config) {
-        return report.getRawReport(config);
+        return inspectionReport.getRawReport(config);
     }
 
     private Report readSonarReport(FilePath workspace, String sonarReportPath) throws IOException,
@@ -76,12 +109,14 @@ public class SonarConnector implements InspectionReportAdapter {
 
         // check if report exists
         if (!reportPath.exists()) {
-            TaskListenerLogger.logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.sonar.report.not.exists", reportPath);
+            TaskListenerLogger
+                    .logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.sonar.report.not.exists", reportPath);
             return null;
         }
         // check if report is a file
         if (reportPath.isDirectory()) {
-            TaskListenerLogger.logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.sonar.report.path.directory", reportPath);
+            TaskListenerLogger
+                    .logMessage(listener, LOGGER, Level.SEVERE, "jenkins.plugin.error.sonar.report.path.directory", reportPath);
             return null;
         }
 
@@ -91,13 +126,15 @@ public class SonarConnector implements InspectionReportAdapter {
         String reportJson = reportPath.readToString();
         Report report = builder.fromJson(reportJson);
 
-        TaskListenerLogger.logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.inspection.report.loaded", report.getIssues().size());
+        TaskListenerLogger
+                .logMessage(listener, LOGGER, Level.INFO, "jenkins.plugin.inspection.report.loaded", report.getIssues().size());
         return report;
     }
 
     static class ReportInfo {
 
         public final SubJobConfig config;
+
         public final Report report;
 
         public ReportInfo(SubJobConfig config, Report report) {

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/review/GerritReviewBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/review/GerritReviewBuilder.java
@@ -1,22 +1,26 @@
 package org.jenkinsci.plugins.sonargerrit.review;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.jenkinsci.plugins.sonargerrit.config.NotificationConfig;
+import org.jenkinsci.plugins.sonargerrit.config.ReviewConfig;
+import org.jenkinsci.plugins.sonargerrit.config.ScoreConfig;
+import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
+import org.jenkinsci.plugins.sonargerrit.review.formatter.CustomIssueFormatter;
+import org.jenkinsci.plugins.sonargerrit.review.formatter.CustomReportFormatter;
+
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.gerrit.extensions.api.changes.NotifyHandling;
 import com.google.gerrit.extensions.api.changes.ReviewInput;
-import org.jenkinsci.plugins.sonargerrit.config.InspectionConfig;
-import org.jenkinsci.plugins.sonargerrit.config.NotificationConfig;
-import org.jenkinsci.plugins.sonargerrit.config.ReviewConfig;
-import org.jenkinsci.plugins.sonargerrit.config.ScoreConfig;
-import org.jenkinsci.plugins.sonargerrit.inspection.entity.Issue;
-import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
-import org.jenkinsci.plugins.sonargerrit.review.formatter.CustomIssueFormatter;
-import org.jenkinsci.plugins.sonargerrit.review.formatter.CustomReportFormatter;
-
-import javax.annotation.Nullable;
-import java.util.*;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -31,18 +35,18 @@ public class GerritReviewBuilder {
     private ReviewConfig reviewConfig;
     private ScoreConfig scoreConfig;
     private NotificationConfig notificationConfig;
-    private InspectionConfig inspectionConfig;
+    private String serverUrl;
 
     public GerritReviewBuilder(Multimap<String, IssueAdapter> finalIssuesToComment,
-                               Multimap<String, IssueAdapter> finalIssuesToScore,
-                               ReviewConfig reviewConfig, ScoreConfig scoreConfig,
-                               NotificationConfig notificationConfig, InspectionConfig inspectionConfig) {
+            Multimap<String, IssueAdapter> finalIssuesToScore,
+            ReviewConfig reviewConfig, ScoreConfig scoreConfig,
+            NotificationConfig notificationConfig, String serverUrl) {
         this.finalIssuesToComment = finalIssuesToComment;
         this.finalIssuesToScore = finalIssuesToScore;
         this.reviewConfig = reviewConfig;
         this.scoreConfig = scoreConfig;
         this.notificationConfig = notificationConfig;
-        this.inspectionConfig = inspectionConfig;
+        this.serverUrl = serverUrl;
     }
 
     public ReviewInput buildReview() {
@@ -88,7 +92,7 @@ public class GerritReviewBuilder {
     }
 
     private Map<String, List<ReviewInput.CommentInput>> generateComments() {
-        Map<String, List<ReviewInput.CommentInput>> file2comments = new HashMap<String, List<ReviewInput.CommentInput>>();
+        Map<String, List<ReviewInput.CommentInput>> file2comments = new HashMap<>();
         for (String file : finalIssuesToComment.keySet()) {
             Collection<IssueAdapter> issues = finalIssuesToComment.get(file);
             Collection<ReviewInput.CommentInput> comments = Collections2.transform(issues, new IssueToCommentTransformation());
@@ -104,7 +108,7 @@ public class GerritReviewBuilder {
         }
 
         String commentTemplate = reviewConfig.getIssueCommentTemplate();
-        String message = new CustomIssueFormatter(input, commentTemplate, inspectionConfig.getServerURL()).getMessage();
+        String message = new CustomIssueFormatter(input, commentTemplate, serverUrl).getMessage();
 
         ReviewInput.CommentInput commentInput = new ReviewInput.CommentInput();
         commentInput.id = input.getKey();
@@ -114,6 +118,8 @@ public class GerritReviewBuilder {
     }
 
     private class IssueToCommentTransformation implements Function<IssueAdapter, ReviewInput.CommentInput> {
+
+
         @Nullable
         @Override
         public ReviewInput.CommentInput apply(@Nullable IssueAdapter input) {

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarClient.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarClient.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.plugins.sonargerrit.sonar;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.sonargerrit.inspection.entity.Report;
+import org.jenkinsci.plugins.sonargerrit.sonar.dto.ComponentSearchResult;
+
+import java.util.logging.Logger;
+
+import hudson.AbortException;
+import hudson.plugins.sonar.SonarInstallation;
+
+public class SonarClient {
+    private static final Logger LOGGER = Logger.getLogger(SonarClient.class.getName());
+
+    private final String serverUrl;
+
+    private final Client client;
+
+    public SonarClient(SonarInstallation sonarInstallation, StringCredentials credentials) throws AbortException {
+        this.serverUrl = sonarInstallation.getServerUrl();
+
+        if (credentials == null) {
+            throw new AbortException("Missing Server authentication token for SonarQube Server " + sonarInstallation.getName());
+        }
+        String token = credentials.getSecret().getPlainText();
+        HttpAuthenticationFeature basicAuth = HttpAuthenticationFeature.basic(token, "");
+
+        client = ClientBuilder.newClient();
+        client.register(basicAuth);
+    }
+
+    public Report fetchIssues(String component, String pullrequestKey) {
+        WebTarget target = client.target(serverUrl).path("api").path("issues").path("search")
+                .queryParam("componentKeys", component)
+                .queryParam("pullRequest", pullrequestKey);
+
+        LOGGER.info(() -> "Fetch issues from " + target.toString());
+
+        Report report = target.request(MediaType.APPLICATION_JSON_TYPE).get(Report.class);
+        // Pull Request Analysis only reports new issues, attribute is not present in JSON response
+        report.getIssues().forEach(issue -> issue.setNew(true));
+
+        LOGGER.info(() -> "Report has " + report.getIssues().size() + " issues.");
+
+        return report;
+    }
+
+    /**
+     * @see  <a href="https://sonarqube.mamdev.server.lan/web_api/api/components">https://sonarqube.mamdev.server.lan/web_api/api/components</a>
+     *
+     */
+    public ComponentSearchResult fetchComponent(String component) {
+        ComponentSearchResult componentSearchResult = null;
+        Integer total = null;
+
+        for (int currentPage = 1; total == null || (currentPage - 1) * 500 < total; currentPage++) {
+            ComponentSearchResult pageResult = fetchComponent(component, currentPage);
+            if (componentSearchResult == null) {
+                componentSearchResult = pageResult;
+                total = pageResult.getPaging().getTotal();
+            } else {
+                componentSearchResult.getComponents().addAll(pageResult.getComponents());
+            }
+        }
+
+        return componentSearchResult;
+    }
+
+    private ComponentSearchResult fetchComponent(String component, Integer page) {
+        WebTarget target = client.target(serverUrl).path("api").path("components").path("search")
+                .queryParam("qualifiers", "TRK") // TRK - Projects
+                .queryParam("ps", 500) // page size
+                .queryParam("p", page); // 1-based page number
+
+        if (component != null && !component.isEmpty()) {
+            target = target.queryParam("q", component); // component key
+        }
+
+        return target.request(MediaType.APPLICATION_JSON_TYPE).get(ComponentSearchResult.class);
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarClient.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarClient.java
@@ -54,6 +54,8 @@ public class SonarClient {
     /**
      * @see  <a href="https://sonarqube.mamdev.server.lan/web_api/api/components">https://sonarqube.mamdev.server.lan/web_api/api/components</a>
      *
+     * @param component name of component which should be fetched
+     * @return result matching the component name
      */
     public ComponentSearchResult fetchComponent(String component) {
         ComponentSearchResult componentSearchResult = null;

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
@@ -17,7 +17,7 @@ import hudson.plugins.sonar.SonarInstallation;
 import hudson.security.ACL;
 
 public class SonarUtil {
-    private static Pattern componentKeyPattern = Pattern.compile(".*\\((?<key>.*)\\)");
+    private static final Pattern componentKeyPattern = Pattern.compile(".*\\((?<key>.*)\\)");
 
     private SonarUtil() {}
 
@@ -54,9 +54,6 @@ public class SonarUtil {
                 CredentialsMatchers.withId(sonarInstallation.getCredentialsId())
         );
 
-        if (credentials == null) {
-            throw new IllegalStateException("Missing Server authentication token for SonarQube Server " + sonarInstallation.getName());
-        }
-        return new SonarClient(sonarInstallation, credentials);
+        return new SonarClient(sonarInstallation, credentials, null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
@@ -19,7 +19,10 @@ import hudson.security.ACL;
 public class SonarUtil {
     private static Pattern componentKeyPattern = Pattern.compile(".*\\((?<key>.*)\\)");
 
-    /** Name (group:componentKey) -> group:componentKey */
+    /**
+     * @param value (group:componentKey)
+     * @return group:componentKey
+     */
     public static String isolateComponentKey(String value) {
         Matcher matcher = componentKeyPattern.matcher(value);
         if (matcher.matches()) {
@@ -32,7 +35,9 @@ public class SonarUtil {
     /**
      * Possible pattern: Name (key) or key
      *
-     * @return key
+     * @param sonarInstallationName name of SonarQube installation which should be used
+     * @return client to access SonarQube
+     * @throws AbortException if Sonar installation cannot be found
      */
     public static SonarClient getSonarClient(String sonarInstallationName) throws AbortException {
         SonarInstallation sonarInstallation = SonarInstallationReader.getSonarInstallation(sonarInstallationName);

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
@@ -19,6 +19,8 @@ import hudson.security.ACL;
 public class SonarUtil {
     private static Pattern componentKeyPattern = Pattern.compile(".*\\((?<key>.*)\\)");
 
+    private SonarUtil() {}
+
     /**
      * @param value (group:componentKey)
      * @return group:componentKey

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/SonarUtil.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.sonargerrit.sonar;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.sonargerrit.config.SonarInstallationReader;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
+import hudson.AbortException;
+import hudson.model.ItemGroup;
+import hudson.plugins.sonar.SonarInstallation;
+import hudson.security.ACL;
+
+public class SonarUtil {
+    private static Pattern componentKeyPattern = Pattern.compile(".*\\((?<key>.*)\\)");
+
+    /** Name (group:componentKey) -> group:componentKey */
+    public static String isolateComponentKey(String value) {
+        Matcher matcher = componentKeyPattern.matcher(value);
+        if (matcher.matches()) {
+            return matcher.group("key");
+        } else {
+            return value;
+        }
+    }
+
+    /**
+     * Possible pattern: Name (key) or key
+     *
+     * @return key
+     */
+    public static SonarClient getSonarClient(String sonarInstallationName) throws AbortException {
+        SonarInstallation sonarInstallation = SonarInstallationReader.getSonarInstallation(sonarInstallationName);
+        List<StringCredentials> stringCredentials = CredentialsProvider.lookupCredentials(
+                StringCredentials.class,
+                (ItemGroup<?>) null,
+                ACL.SYSTEM,
+                (DomainRequirement) null
+        );
+        StringCredentials credentials = CredentialsMatchers.firstOrNull(
+                stringCredentials,
+                CredentialsMatchers.withId(sonarInstallation.getCredentialsId())
+        );
+
+        if (credentials == null) {
+            throw new IllegalStateException("Missing Server authentication token for SonarQube Server " + sonarInstallation.getName());
+        }
+        return new SonarClient(sonarInstallation, credentials);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/Component.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/Component.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.sonargerrit.sonar.dto;
+
+public class Component {
+    private String name;
+    private String key;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/ComponentSearchResult.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/ComponentSearchResult.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.sonargerrit.sonar.dto;
+
+import java.util.List;
+
+public class ComponentSearchResult {
+    private Paging paging;
+    private List<Component> components;
+
+    public Paging getPaging() {
+        return paging;
+    }
+
+    public void setPaging(Paging paging) {
+        this.paging = paging;
+    }
+
+    public List<Component> getComponents() {
+        return components;
+    }
+
+    public void setComponents(List<Component> components) {
+        this.components = components;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/Paging.java
+++ b/src/main/java/org/jenkinsci/plugins/sonargerrit/sonar/dto/Paging.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.sonargerrit.sonar.dto;
+
+public class Paging {
+    private Integer pageIndex;
+    private Integer pageSize;
+    private Integer total;
+
+    public Integer getPageIndex() {
+        return pageIndex;
+    }
+
+    public void setPageIndex(Integer pageIndex) {
+        this.pageIndex = pageIndex;
+    }
+
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public Integer getTotal() {
+        return total;
+    }
+
+    public void setTotal(Integer total) {
+        this.total = total;
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,6 +7,10 @@ jenkins.plugin.connected.to.gerrit=Connected to Gerrit: server name: %s. Change 
 jenkins.plugin.review.sent=Review has been sent
 jenkins.plugin.issues.to.comment=Issues to be commented: %s
 jenkins.plugin.issues.to.score=Issues to be involved in score calculation: %s
+jenkins.plugin.sonar.start=Starting Sonar to Gerrit Publisher with analysis type %s
+jenkins.plugin.sonar.fetch=Fetch issues from %s
+jenkins.plugin.sonar.report=Report has %s issues
+jenkins.plugin.sonar.issues.wait=Processing can take some time, so wait %s seconds ...
 
 # default values
 jenkins.plugin.default.review.body=<severity> SonarQube violation:\n\n\n<message>\n\n\nRead more: <rule_url>
@@ -26,6 +30,10 @@ jenkins.plugin.error.gerrit.revision.data.not.loaded=Revision data was not loade
 jenkins.plugin.error.path.no.project.config.available=No SonarQube report available. Please check your Project Settings
 jenkins.plugin.error.sonar.report.not.exists=SonarQube report '%s' does not exist. Please check plugin settings
 jenkins.plugin.error.sonar.report.path.directory='%s' is a directory and not a SonarQube report file. Please check plugin settings
+jenkins.plugin.error.sonar.config.missing=Missing SonarGlobalConfiguration -> Install SonarQube Scanner for Jenkins: https://plugins.jenkins.io/sonar/
+jenkins.plugin.error.sonar.server.missing=No SonarQube server found -> Add one in Jenkins system configuration - SonarQube servers
+jenkins.plugin.error.sonar.server.notfound=SonarQube '%s' not found -> Add it in Jenkins system configuration - SonarQube servers
+jenkins.plugin.error.sonar.server.authmissing=Missing Server authentication token for SonarQube Server '%s'
 jenkins.plugin.error.more.than.one.file.matched=Auto match failed for file '%s': more than one changed file found.
 
 # form validation errors

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -10,7 +10,7 @@ jenkins.plugin.issues.to.score=Issues to be involved in score calculation: %s
 jenkins.plugin.sonar.start=Starting Sonar to Gerrit Publisher with analysis type %s
 jenkins.plugin.sonar.fetch=Fetch issues from %s
 jenkins.plugin.sonar.report=Report has %s issues
-jenkins.plugin.sonar.issues.wait=Processing can take some time, so wait %s seconds ...
+jenkins.plugin.sonar.issues.wait=Processing can take some time, so wait %s ...
 
 # default values
 jenkins.plugin.default.review.body=<severity> SonarQube violation:\n\n\n<message>\n\n\nRead more: <rule_url>

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.jelly
@@ -28,7 +28,7 @@
                 </f:entry>
             </j:if>
 
-            <f:entry title="${%jenkins.plugin.settings.inspection.pullrequest.key}" field="pullrequestKey">
+            <f:entry title="${%jenkins.plugin.settings.inspection.pullrequest.key}" field="pullRequestKey">
                 <f:textbox default="${descriptor.SONAR_PULLREQUEST_KEY}"/>
             </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.jelly
@@ -1,41 +1,87 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%jenkins.plugin.settings.inspection.server.url}" field="serverURL">
-        <f:textbox default="${descriptor.SONAR_URL}" placeholder="${descriptor.SONAR_URL}"/>
-    </f:entry>
 
-    <f:radioBlock name="type"
-                  title="${%jenkins.plugin.settings.inspection.base.config}"
-                  value="${descriptor.BASE_TYPE}"
-                  checked="${instance.isType(descriptor.BASE_TYPE)}"
+    <f:radioBlock name="analysisType"
+                  title="${%jenkins.plugin.settings.inspection.analysis.pullRequest}"
+                  value="${descriptor.ANALYSIS_TYPE_PULL_REQUEST}"
+                  checked="${instance.analysisType == descriptor.ANALYSIS_TYPE_PULL_REQUEST}"
                   inline="true">
         <f:nested>
-            <f:property
-                    title="${%jenkins.plugin.settings.inspection.base.config}"
-                    field="baseConfig"/>
-            <f:entry
-                    title="${%jenkins.plugin.settings.inspection.base.config.allow.auto.match}"
-                    field="autoMatch">
-                <f:checkbox selected="${autoMatch}" default="${descriptor.AUTO_MATCH}"/>
+            <!-- SonarQube Installation -->
+            <j:set var="sonars" value="${instance.sonarInstallations}"/>
+            <j:if test="${empty(sonars)}">
+                <!-- no SonarQube installation is configured, so warn the user now -->
+                <f:entry title="${%SonarInstallation}">
+                    <div class="error">${%SonarInstallation.error(rootURL)}</div>
+                </f:entry>
+            </j:if>
+
+            <j:if test="${sonars.size() gt 0}">
+                <!-- choise not necessary if there's no choice -->
+                <f:entry title="${%SonarInstallation}: " help="/plugin/sonar/help-sonar-installation.html">
+                    <select class="setting-input" name="sonarInstallationName">
+                        <j:forEach var="inst" items="${sonars}">
+                            <f:option value="${inst.name}" selected="${inst.name==instance.sonarInstallationName}">${inst.name}
+                            </f:option>
+                        </j:forEach>
+                    </select>
+                </f:entry>
+            </j:if>
+
+            <f:entry title="${%jenkins.plugin.settings.inspection.pullrequest.key}" field="pullrequestKey">
+                <f:textbox default="${descriptor.SONAR_PULLREQUEST_KEY}"/>
+            </f:entry>
+
+            <f:entry title="${%jenkins.plugin.settings.inspection.component}" field="component">
+                <f:combobox/>
             </f:entry>
         </f:nested>
     </f:radioBlock>
 
-    <f:radioBlock name="type"
-                  title="${%jenkins.plugin.settings.inspection.list.configs}"
-                  value="${descriptor.MULTI_TYPE}"
-                  checked="${instance.isType(descriptor.MULTI_TYPE)}"
+    <f:radioBlock name="analysisType"
+                  title="${%jenkins.plugin.settings.inspection.analysis.previewMode}"
+                  value="${descriptor.ANALYSIS_TYPE_PREVIEW_MODE}"
+                  checked="${instance.analysisType == descriptor.ANALYSIS_TYPE_PREVIEW_MODE}"
                   inline="true">
         <f:nested>
-            <f:entry>
-                <f:repeatableProperty field="subJobConfigs" minimum="1" noAddButton="false">
-                    <f:entry title="">
-                        <div align="right">
-                            <f:repeatableDeleteButton/>
-                        </div>
-                    </f:entry>
-                </f:repeatableProperty>
+            <f:entry title="${%jenkins.plugin.settings.inspection.server.url}" field="serverURL">
+                <f:textbox default="${descriptor.SONAR_URL}" placeholder="${descriptor.SONAR_URL}"/>
             </f:entry>
+
+            <f:radioBlock name="type"
+                          title="${%jenkins.plugin.settings.inspection.base.config}"
+                          value="${descriptor.BASE_TYPE}"
+                          checked="${instance.isType(descriptor.BASE_TYPE)}"
+                          inline="true">
+                <f:nested>
+                    <f:property
+                            title="${%jenkins.plugin.settings.inspection.base.config}"
+                            field="baseConfig"/>
+                    <f:entry
+                            title="${%jenkins.plugin.settings.inspection.base.config.allow.auto.match}"
+                            field="autoMatch">
+                        <f:checkbox selected="${autoMatch}" default="${descriptor.AUTO_MATCH}"/>
+                    </f:entry>
+                </f:nested>
+            </f:radioBlock>
+
+            <f:radioBlock name="type"
+                          title="${%jenkins.plugin.settings.inspection.list.configs}"
+                          value="${descriptor.MULTI_TYPE}"
+                          checked="${instance.isType(descriptor.MULTI_TYPE)}"
+                          inline="true">
+                <f:nested>
+                    <f:entry>
+                        <f:repeatableProperty field="subJobConfigs" minimum="1" noAddButton="false">
+                            <f:entry title="">
+                                <div align="right">
+                                    <f:repeatableDeleteButton/>
+                                </div>
+                            </f:entry>
+                        </f:repeatableProperty>
+                    </f:entry>
+                </f:nested>
+            </f:radioBlock>
         </f:nested>
     </f:radioBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.properties
@@ -9,4 +9,4 @@ SonarInstallation.error=There are no SonarQube instances configured.<br/>\
   Please configure a SonarQube instance in the <a href="{0}/configure" target="_new">system configuration - SonarQube servers</a>.
 SonarInstallation=Sonar Installations
 jenkins.plugin.settings.inspection.analysis.previewMode=Preview Mode Analysis (until SonarQube 7.6)
-jenkins.plugin.settings.inspection.analysis.pullRequest=Pull Request Analysis
+jenkins.plugin.settings.inspection.analysis.pullRequest=Pull Request Analysis (since SonarQube 7.2)

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/config.properties
@@ -1,4 +1,12 @@
 jenkins.plugin.settings.inspection.server.url=Server URL
+jenkins.plugin.settings.inspection.server.token=Server Login Token
+jenkins.plugin.settings.inspection.pullrequest.key=Pull Request Key
+jenkins.plugin.settings.inspection.component=Sonar Project Key
 jenkins.plugin.settings.inspection.base.config=Project configuration
 jenkins.plugin.settings.inspection.base.config.allow.auto.match=Allow auto match
 jenkins.plugin.settings.inspection.list.configs=Sub-project configurations
+SonarInstallation.error=There are no SonarQube instances configured.<br/>\
+  Please configure a SonarQube instance in the <a href="{0}/configure" target="_new">system configuration - SonarQube servers</a>.
+SonarInstallation=Sonar Installations
+jenkins.plugin.settings.inspection.analysis.previewMode=Preview Mode Analysis (until SonarQube 7.6)
+jenkins.plugin.settings.inspection.analysis.pullRequest=Pull Request Analysis

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/help-serverToken.html
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/InspectionConfig/help-serverToken.html
@@ -1,0 +1,3 @@
+<div>
+    Token of the SonarQube instance used for static code analysis
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/config.properties
@@ -1,6 +1,6 @@
 jenkins.plugin.settings.gerrit.filter.severity=Report issues having severity level higher or equal to:
 jenkins.plugin.settings.gerrit.filter.new=Report new issues only?
-jenkins.plugin.settings.gerrit.filter.new.description=Reports new as well as existing issues when unchecked. For SonarQube 7 will always only new issues be reported (Checkbox has no effect).
+jenkins.plugin.settings.gerrit.filter.new.description=Reports new as well as existing issues when unchecked. For SonarQube 7 will report only new issues (Checkbox has no effect).
 jenkins.plugin.settings.gerrit.filter.lines.changed=Affect changed lines only
 jenkins.plugin.settings.gerrit.filter.lines.changed.description=Reports issues for changed as well as not changed lines in files affected by patchset when unchecked
 
@@ -9,6 +9,5 @@ MINOR=Minor
 MAJOR=Major
 CRITICAL=Critical
 BLOCKER=Blocker
-
 
 

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/config.properties
@@ -1,6 +1,6 @@
 jenkins.plugin.settings.gerrit.filter.severity=Report issues having severity level higher or equal to:
 jenkins.plugin.settings.gerrit.filter.new=Report new issues only?
-jenkins.plugin.settings.gerrit.filter.new.description=Reports new as well as existing issues when unchecked
+jenkins.plugin.settings.gerrit.filter.new.description=Reports new as well as existing issues when unchecked. For SonarQube 7 will always only new issues be reported (Checkbox has no effect).
 jenkins.plugin.settings.gerrit.filter.lines.changed=Affect changed lines only
 jenkins.plugin.settings.gerrit.filter.lines.changed.description=Reports issues for changed as well as not changed lines in files affected by patchset when unchecked
 

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/help-newIssuesOnly.html
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/help-newIssuesOnly.html
@@ -1,7 +1,7 @@
 <div>
     <p>
-        Only <b>new</b> SonarQube issues to be commented in Gerrit when checked.
-        Modified files to be commented with <b>all</b> corresponding issues when unchecked.
+        Only <strong>new</strong> SonarQube issues to be commented in Gerrit when checked.
+        Modified files to be commented with <strong>all</strong> corresponding issues when unchecked.
     </p>
     <p>
         When using the SonarQube 7 configuration only new issues will be reported even if this checkbox is unchecked.

--- a/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/help-newIssuesOnly.html
+++ b/src/main/resources/org/jenkinsci/plugins/sonargerrit/config/IssueFilterConfig/help-newIssuesOnly.html
@@ -1,4 +1,12 @@
 <div>
-    Only <b>new</b> SonarQube issues to be commented in Gerrit when checked.
-    Modified files to be commented with <b>all</b> corresponding issues when unchecked.
+    <p>
+        Only <b>new</b> SonarQube issues to be commented in Gerrit when checked.
+        Modified files to be commented with <b>all</b> corresponding issues when unchecked.
+    </p>
+    <p>
+        When using the SonarQube 7 configuration only new issues will be reported even if this checkbox is unchecked.
+        This is due to the fact, that
+        <a href="https://docs.sonarqube.org/7.9/analysis/pull-request/">SonarQube 7 - Pull Request Analysis </a>
+        only contains new issues.
+    </p>
 </div>

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/DummyRevisionApi.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/DummyRevisionApi.java
@@ -30,6 +30,11 @@ public class DummyRevisionApi implements RevisionApi {
         return getFileApi(path);
     }
 
+    @Override
+    public CommitInfo commit(boolean addLinks) throws RestApiException {
+        return null;
+    }
+
     private FileApi getFileApi(final String path) {
         return new FileApi() {
             @Override
@@ -101,7 +106,17 @@ public class DummyRevisionApi implements RevisionApi {
     }
 
     @Override
-    public void review(ReviewInput in) throws RestApiException {
+    public String description() throws RestApiException {
+        return null;
+    }
+
+    @Override
+    public void description(String description) throws RestApiException {
+
+    }
+
+    @Override
+    public ReviewResult review(ReviewInput in) throws RestApiException {
         throw new UnsupportedOperationException("This is a dummy test class");
     }
 
@@ -138,6 +153,11 @@ public class DummyRevisionApi implements RevisionApi {
     @Override
     public boolean canRebase() {
         throw new UnsupportedOperationException("This is a dummy test class");
+    }
+
+    @Override
+    public RevisionReviewerApi reviewer(String id) throws RestApiException {
+        return null;
     }
 
     @Override
@@ -216,6 +236,11 @@ public class DummyRevisionApi implements RevisionApi {
     }
 
     @Override
+    public List<String> queryFiles(String query) throws RestApiException {
+        return null;
+    }
+
+    @Override
     public MergeListRequest getMergeList() throws RestApiException {
         throw new UnsupportedOperationException("This is a dummy test class");
     }
@@ -236,6 +261,11 @@ public class DummyRevisionApi implements RevisionApi {
     }
 
     @Override
+    public String etag() throws RestApiException {
+        return null;
+    }
+
+    @Override
     public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
         throw new UnsupportedOperationException("This is a dummy test class");
     }
@@ -246,8 +276,18 @@ public class DummyRevisionApi implements RevisionApi {
     }
 
     @Override
+    public EditInfo applyFix(String fixId) throws RestApiException {
+        return null;
+    }
+
+    @Override
     public BinaryResult submitPreview() throws RestApiException {
         throw new UnsupportedOperationException("This is a dummy test class");
+    }
+
+    @Override
+    public BinaryResult submitPreview(String format) throws RestApiException {
+        return null;
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/ComponentPathBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/ComponentPathBuilderTest.java
@@ -5,7 +5,6 @@ import hudson.FilePath;
 import junit.framework.Assert;
 import org.jenkinsci.plugins.sonargerrit.config.InspectionConfig;
 import org.jenkinsci.plugins.sonargerrit.config.SubJobConfig;
-import org.jenkinsci.plugins.sonargerrit.inspection.entity.Issue;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.Report;
 import org.junit.Test;
@@ -151,7 +150,7 @@ public class ComponentPathBuilderTest {
     }
 
     protected SonarConnector readSonarReport(SubJobConfig... configs) throws IOException, InterruptedException {
-        SonarConnector connector = new SonarConnector(null, buildInspectionConfig(configs));
+        SonarConnector connector = new SonarConnector(null, null, buildInspectionConfig(configs));
         connector.readSonarReports(new FilePath(new File("")));
         return connector;
     }

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/inspection/sonarqube/SonarConnectorTest.java
@@ -70,7 +70,7 @@ public class SonarConnectorTest {
     }
 
     protected SonarConnector readSonarReport(SubJobConfig... configs) throws IOException, InterruptedException {
-        SonarConnector connector = new SonarConnector(null, buildInspectionConfig(configs));
+        SonarConnector connector = new SonarConnector(null, null, buildInspectionConfig(configs));
         connector.readSonarReports(new FilePath(new File("")));
         return connector;
     }

--- a/src/test/java/org/jenkinsci/plugins/sonargerrit/review/ReviewResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/sonargerrit/review/ReviewResultTest.java
@@ -1,8 +1,5 @@
 package org.jenkinsci.plugins.sonargerrit.review;
 
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.gerrit.extensions.api.changes.ReviewInput;
 import org.jenkinsci.plugins.sonargerrit.ReportBasedTest;
 import org.jenkinsci.plugins.sonargerrit.SonarToGerritPublisher;
 import org.jenkinsci.plugins.sonargerrit.config.ReviewConfig;
@@ -10,11 +7,13 @@ import org.jenkinsci.plugins.sonargerrit.config.ScoreConfig;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.Issue;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.IssueAdapter;
 import org.jenkinsci.plugins.sonargerrit.inspection.entity.Severity;
-import org.jenkinsci.plugins.sonargerrit.inspection.sonarqube.SonarQubeIssueAdapter;
-import org.jenkinsci.plugins.sonargerrit.review.GerritReviewBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gerrit.extensions.api.changes.ReviewInput;
 
 /**
  * Project: Sonar-Gerrit Plugin
@@ -42,7 +41,7 @@ public class ReviewResultTest extends ReportBasedTest {
     protected ReviewInput getReviewResult() {
         GerritReviewBuilder builder = new GerritReviewBuilder(commentIssues, scoreIssues,
                 publisher.getReviewConfig(), publisher.getScoreConfig(),
-                publisher.getNotificationConfig(), publisher.getInspectionConfig());
+                publisher.getNotificationConfig(), publisher.getInspectionConfig().getServerURL());
         return builder.buildReview();
     }
 


### PR DESCRIPTION

> Incompatibility with Sonar 7.7
--
 
> Starting with Sonarqube 7.7 the preview mode (-Dsonar.analysis.mode=preview) was removed, making it incompatible with the plugin.
 
> Sonarqube release notes say it now has "native support for short-living branches" https://www.sonarqube.org/sonarqube-7-7/, author will make an effort to integrate these features. Contributions are appreciated
 

This PR is a contribution to the problem mentioned above. Feedback to this PR is highly appreciated as this is my first contribution to a Jenkins Plugin.
 
### Chosen solution
- GUI: Introduce a switch for Pull Request/SQ 7.7 and Preview Mode
- Workflow: As JSON file is no longer present, fetch result directly from SonarQube: https://sonarqube-server.com/api/issues/search?componentKeys=myComponent&pullRequest=4711 and create a Report object like formerly based on JSON file.
- Add dependency to [Token Macro | Jenkins plugin](https://plugins.jenkins.io/token-macro/) in order to evaluate expressions like `${GERRIT_CHANGE_NUMBER}` as pullRequestKey
- Add dependency to [SonarQube Scanner | Jenkins plugin](https://plugins.jenkins.io/sonar/) in order to reuse SonarQube server config.

### Hint
As some plugins were not compatible with Jenkins 1.625 I had to upgrade some dependencies. Maybe not all were required, but probably it was a good idea anyway to stay up to date.
- Java 7 -> 8
- Jenkins parent 2.11 -> 4.4 (this also upgrades the Jenkins version which is used for testing)



